### PR TITLE
Standardize header, footer, and layout for day pages

### DIFF
--- a/day_1.html
+++ b/day_1.html
@@ -55,22 +55,11 @@
 
     <div class="container mx-auto px-4 sm:px-6 lg:px-8 mt-8">
         <div class="flex flex-col md:flex-row md:space-x-8 lg:space-x-12">
-            <aside class="w-full md:w-1/4 lg:w-1/5">
-                <nav id="toc" class="sticky top-24">
-                    <h3 class="font-bold text-slate-900 mb-4 text-lg">Table of Contents</h3>
-                    <ul class="space-y-2">
-                        <li><a href="#theory" class="toc-link block border-l-4 border-transparent pl-4 text-slate-600 hover:text-indigo-600 hover:border-indigo-300">Theory Deep Dive</a></li>
-                        <li><a href="#practice" class="toc-link block border-l-4 border-transparent pl-4 text-slate-600 hover:text-indigo-600 hover:border-indigo-300">Coding Practice</a></li>
-                        <li><a href="#problems" class="toc-link block border-l-4 border-transparent pl-4 text-slate-600 hover:text-indigo-600 hover:border-indigo-300">Problem Solving</a></li>
-                        <li><a href="#uml" class="toc-link block border-l-4 border-transparent pl-4 text-slate-600 hover:text-indigo-600 hover:border-indigo-300">UML/Schema Design</a></li>
-                        <li><a href="#case-study" class="toc-link block border-l-4 border-transparent pl-4 text-slate-600 hover:text-indigo-600 hover:border-indigo-300">Case Study</a></li>
-                        <li><a href="#quiz" class="toc-link block border-l-4 border-transparent pl-4 text-slate-600 hover:text-indigo-600 hover:border-indigo-300">Knowledge Check</a></li>
-                        <li><a href="#challenge" class="toc-link block border-l-4 border-transparent pl-4 text-slate-600 hover:text-indigo-600 hover:border-indigo-300">Self-Assessment</a></li>
-                    </ul>
-                </nav>
-            </aside>
-
             <main class="w-full md:w-3/4 lg:w-4/5 mt-8 md:mt-0">
+                <a href="lld_homepage.html" class="text-teal-600 hover:text-teal-800 font-semibold transition-colors duration-200 inline-flex items-center">
+                    <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path></svg>
+                    Return to Homepage
+                </a>
                 <div class="mb-12">
                     <h1 class="text-4xl font-extrabold text-slate-900 tracking-tight">OOP Foundations: Day 1</h1>
                     <p class="mt-2 text-xl text-slate-600">An Introduction to Encapsulation & Abstraction in C#</p>
@@ -705,13 +694,27 @@ public class VendingMachine
                      </article>
                 </section>
             </main>
+            <aside class="w-full md:w-1/4 lg:w-1/5">
+                <nav id="toc" class="sticky top-24">
+                    <h3 class="font-bold text-slate-900 mb-4 text-lg">Table of Contents</h3>
+                    <ul class="space-y-2">
+                        <li><a href="#theory" class="toc-link block border-l-4 border-transparent pl-4 text-slate-600 hover:text-indigo-600 hover:border-indigo-300">Theory Deep Dive</a></li>
+                        <li><a href="#practice" class="toc-link block border-l-4 border-transparent pl-4 text-slate-600 hover:text-indigo-600 hover:border-indigo-300">Coding Practice</a></li>
+                        <li><a href="#problems" class="toc-link block border-l-4 border-transparent pl-4 text-slate-600 hover:text-indigo-600 hover:border-indigo-300">Problem Solving</a></li>
+                        <li><a href="#uml" class="toc-link block border-l-4 border-transparent pl-4 text-slate-600 hover:text-indigo-600 hover:border-indigo-300">UML/Schema Design</a></li>
+                        <li><a href="#case-study" class="toc-link block border-l-4 border-transparent pl-4 text-slate-600 hover:text-indigo-600 hover:border-indigo-300">Case Study</a></li>
+                        <li><a href="#quiz" class="toc-link block border-l-4 border-transparent pl-4 text-slate-600 hover:text-indigo-600 hover:border-indigo-300">Knowledge Check</a></li>
+                        <li><a href="#challenge" class="toc-link block border-l-4 border-transparent pl-4 text-slate-600 hover:text-indigo-600 hover:border-indigo-300">Self-Assessment</a></li>
+                    </ul>
+                </nav>
+            </aside>
         </div>
     </div>
 
-    <footer class="bg-slate-800 text-slate-400 mt-24">
-        <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8 text-center">
-            <p>&copy; 2025 OOP Learning Module. All Rights Reserved.</p>
-        </div>
+    <footer class="text-center mt-16 py-8 border-t border-slate-200">
+        <p class="text-slate-700 font-semibold">Low-Level Design Bootcamp</p>
+        <p class="text-sm text-slate-500 mt-2">A personalized learning roadmap curated by Mr. Mahesh Singare.</p>
+        <p class="text-xs text-slate-400 mt-4">&copy; 2025. All Rights Reserved.</p>
     </footer>
 
     <script>

--- a/day_2.html
+++ b/day_2.html
@@ -54,30 +54,20 @@
     </style>
 </head>
 <body class="text-slate-800">
-
-    <!-- Gap for customized header -->
-    <header class="w-full h-16 bg-white shadow-sm flex items-center justify-center">
-        <div class="text-slate-500">Your Custom Header Area</div>
+    <header class="text-center mb-10">
+        <h2 id="greeting" class="text-xl text-slate-500">Good Evening!</h2>
+        <h1 class="text-4xl sm:text-5xl font-extrabold text-slate-800 mt-1 tracking-tight">Low-Level Design Bootcamp</h1>
+        <p class="mt-3 text-slate-500 max-w-xl mx-auto">Your 60-Day Interactive Roadmap to Mastering Backend Engineering.</p>
     </header>
 
     <div class="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         <div class="lg:grid lg:grid-cols-12 lg:gap-8">
-            <!-- Sticky Table of Contents -->
-            <nav id="toc" class="hidden lg:block lg:col-span-3 sticky top-24 self-start">
-                <h3 class="text-lg font-semibold text-slate-900 mb-4">On this page</h3>
-                <ul class="space-y-2 text-slate-600">
-                    <li><a href="#theory" class="toc-link block border-l-2 border-transparent pl-4 py-1 hover:text-sky-600 hover:border-sky-600 transition-colors">Theory Topics</a></li>
-                    <li><a href="#coding-practice" class="toc-link block border-l-2 border-transparent pl-4 py-1 hover:text-sky-600 hover:border-sky-600 transition-colors">Coding Practice</a></li>
-                    <li><a href="#problems" class="toc-link block border-l-2 border-transparent pl-4 py-1 hover:text-sky-600 hover:border-sky-600 transition-colors">Problems & Solutions</a></li>
-                    <li><a href="#uml-task" class="toc-link block border-l-2 border-transparent pl-4 py-1 hover:text-sky-600 hover:border-sky-600 transition-colors">UML/Schema Task</a></li>
-                    <li><a href="#case-study" class="toc-link block border-l-2 border-transparent pl-4 py-1 hover:text-sky-600 hover:border-sky-600 transition-colors">Case Study: Parking Lot</a></li>
-                    <li><a href="#knowledge-check" class="toc-link block border-l-2 border-transparent pl-4 py-1 hover:text-sky-600 hover:border-sky-600 transition-colors">Knowledge Check</a></li>
-                    <li><a href="#self-assessment" class="toc-link block border-l-2 border-transparent pl-4 py-1 hover:text-sky-600 hover:border-sky-600 transition-colors">Self-Assessment Challenge</a></li>
-                </ul>
-            </nav>
-
             <!-- Main Content -->
             <main class="lg:col-span-9">
+                <a href="lld_homepage.html" class="text-teal-600 hover:text-teal-800 font-semibold transition-colors duration-200 inline-flex items-center">
+                    <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path></svg>
+                    Return to Homepage
+                </a>
                 <div class="prose prose-slate max-w-none">
                     <h1 class="text-4xl font-bold tracking-tight text-slate-900">OOP Foundations: Day 2</h1>
                     <p class="text-xl text-slate-600 mt-2">Diving into Constructors, Static Members, and the Object Lifecycle.</p>

--- a/day_3.html
+++ b/day_3.html
@@ -112,50 +112,21 @@
     </style>
 </head>
 <body class="w-full">
-    <!-- Gap for custom header -->
-    <div class="h-16 bg-white border-b border-gray-200 flex items-center justify-center text-gray-500">
-        [ Your Custom Header Goes Here ]
-    </div>
+    <header class="text-center mb-10">
+        <h2 id="greeting" class="text-xl text-slate-500">Good Evening!</h2>
+        <h1 class="text-4xl sm:text-5xl font-extrabold text-slate-800 mt-1 tracking-tight">Low-Level Design Bootcamp</h1>
+        <p class="mt-3 text-slate-500 max-w-xl mx-auto">Your 60-Day Interactive Roadmap to Mastering Backend Engineering.</p>
+    </header>
 
     <div class="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex flex-col lg:flex-row lg:space-x-8 py-8">
             
-            <!-- Left Column: Sticky Table of Contents -->
-            <aside class="w-full lg:w-1/4 lg:sticky top-8 self-start mb-8 lg:mb-0">
-                <div class="p-4 bg-white rounded-lg shadow-sm border border-gray-200">
-                    <h3 class="text-lg font-semibold text-[#8D5B4C] mb-4">Lesson Contents</h3>
-                    <nav id="toc-nav">
-                        <ul class="space-y-2">
-                            <li><a href="#introduction" class="toc-link block text-gray-600 hover:text-[#8D5B4C] pl-2">Introduction</a></li>
-                            <li>
-                                <a href="#theory" class="toc-link block font-medium text-gray-800 pl-2">✅ Theory Topics</a>
-                                <ul class="pl-4 mt-2 space-y-2 text-sm">
-                                    <li><a href="#theory-inheritance" class="toc-link block text-gray-600 pl-2">Base & Derived Classes</a></li>
-                                    <li><a href="#theory-abstract-vs-interface" class="toc-link block text-gray-600 pl-2">Abstract Class vs. Interface</a></li>
-                                    <li><a href="#theory-overriding" class="toc-link block text-gray-600 pl-2">Method Overriding</a></li>
-                                    <li><a href="#theory-polymorphism" class="toc-link block text-gray-600 pl-2">Polymorphism in Practice</a></li>
-                                </ul>
-                            </li>
-                            <li>
-                                <a href="#practice" class="toc-link block font-medium text-gray-800 pl-2">💻 Coding Practice</a>
-                                <ul class="pl-4 mt-2 space-y-2 text-sm">
-                                    <li><a href="#practice-shape" class="toc-link block text-gray-600 pl-2">Base: Shape Hierarchy</a></li>
-                                    <li><a href="#practice-animal" class="toc-link block text-gray-600 pl-2">Easy: Animal Hierarchy</a></li>
-                                    <li><a href="#practice-payment" class="toc-link block text-gray-600 pl-2">Medium: Payment Processor</a></li>
-                                    <li><a href="#practice-notification" class="toc-link block text-gray-600 pl-2">Hard: Notification System</a></li>
-                                </ul>
-                            </li>
-                            <li><a href="#uml" class="toc-link block font-medium text-gray-800 pl-2">🎨 UML/Schema Task</a></li>
-                            <li><a href="#case-study" class="toc-link block font-medium text-gray-800 pl-2">🚗 Case Study: Ride-Hailing</a></li>
-                            <li><a href="#quiz" class="toc-link block font-medium text-gray-800 pl-2">🧠 Knowledge Check</a></li>
-                            <li><a href="#challenge" class="toc-link block font-medium text-gray-800 pl-2">🚀 Self-Assessment Challenge</a></li>
-                        </ul>
-                    </nav>
-                </div>
-            </aside>
-
             <!-- Right Column: Main Content -->
             <main class="w-full lg:w-3/4">
+                <a href="lld_homepage.html" class="text-teal-600 hover:text-teal-800 font-semibold transition-colors duration-200 inline-flex items-center">
+                    <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path></svg>
+                    Return to Homepage
+                </a>
                 
                 <!-- Introduction -->
                 <section id="introduction" class="section-card">
@@ -1051,14 +1022,46 @@ public class Program
                     </div>
                 </section>
             </main>
+            <!-- Left Column: Sticky Table of Contents -->
+            <aside class="w-full lg:w-1/4 lg:sticky top-8 self-start mb-8 lg:mb-0">
+                <div class="p-4 bg-white rounded-lg shadow-sm border border-gray-200">
+                    <h3 class="text-lg font-semibold text-[#8D5B4C] mb-4">Lesson Contents</h3>
+                    <nav id="toc-nav">
+                        <ul class="space-y-2">
+                            <li><a href="#introduction" class="toc-link block text-gray-600 hover:text-[#8D5B4C] pl-2">Introduction</a></li>
+                            <li>
+                                <a href="#theory" class="toc-link block font-medium text-gray-800 pl-2">✅ Theory Topics</a>
+                                <ul class="pl-4 mt-2 space-y-2 text-sm">
+                                    <li><a href="#theory-inheritance" class="toc-link block text-gray-600 pl-2">Base & Derived Classes</a></li>
+                                    <li><a href="#theory-abstract-vs-interface" class="toc-link block text-gray-600 pl-2">Abstract Class vs. Interface</a></li>
+                                    <li><a href="#theory-overriding" class="toc-link block text-gray-600 pl-2">Method Overriding</a></li>
+                                    <li><a href="#theory-polymorphism" class="toc-link block text-gray-600 pl-2">Polymorphism in Practice</a></li>
+                                </ul>
+                            </li>
+                            <li>
+                                <a href="#practice" class="toc-link block font-medium text-gray-800 pl-2">💻 Coding Practice</a>
+                                <ul class="pl-4 mt-2 space-y-2 text-sm">
+                                    <li><a href="#practice-shape" class="toc-link block text-gray-600 pl-2">Base: Shape Hierarchy</a></li>
+                                    <li><a href="#practice-animal" class="toc-link block text-gray-600 pl-2">Easy: Animal Hierarchy</a></li>
+                                    <li><a href="#practice-payment" class="toc-link block text-gray-600 pl-2">Medium: Payment Processor</a></li>
+                                    <li><a href="#practice-notification" class="toc-link block text-gray-600 pl-2">Hard: Notification System</a></li>
+                                </ul>
+                            </li>
+                            <li><a href="#uml" class="toc-link block font-medium text-gray-800 pl-2">🎨 UML/Schema Task</a></li>
+                            <li><a href="#case-study" class="toc-link block font-medium text-gray-800 pl-2">🚗 Case Study: Ride-Hailing</a></li>
+                            <li><a href="#quiz" class="toc-link block font-medium text-gray-800 pl-2">🧠 Knowledge Check</a></li>
+                            <li><a href="#challenge" class="toc-link block font-medium text-gray-800 pl-2">🚀 Self-Assessment Challenge</a></li>
+                        </ul>
+                    </nav>
+                </div>
+            </aside>
         </div>
     </div>
     
-    <!-- Consistent Footer -->
-    <footer class="bg-white border-t border-gray-200 mt-12">
-        <div class="max-w-screen-xl mx-auto py-6 px-4 sm:px-6 lg:px-8 text-center text-gray-500">
-            <p>&copy; 2025 OOP Foundations Learning Module. All rights reserved.</p>
-        </div>
+    <footer class="text-center mt-16 py-8 border-t border-slate-200">
+        <p class="text-slate-700 font-semibold">Low-Level Design Bootcamp</p>
+        <p class="text-sm text-slate-500 mt-2">A personalized learning roadmap curated by Mr. Mahesh Singare.</p>
+        <p class="text-xs text-slate-400 mt-4">&copy; 2025. All Rights Reserved.</p>
     </footer>
 
     <script>

--- a/day_4.html
+++ b/day_4.html
@@ -32,29 +32,20 @@
 </head>
 <body class="text-slate-700">
 
-    <!-- CUSTOM HEADER GAP -->
-    <div class="h-16"></div>
+    <header class="text-center mb-10">
+        <h2 id="greeting" class="text-xl text-slate-500">Good Evening!</h2>
+        <h1 class="text-4xl sm:text-5xl font-extrabold text-slate-800 mt-1 tracking-tight">Low-Level Design Bootcamp</h1>
+        <p class="mt-3 text-slate-500 max-w-xl mx-auto">Your 60-Day Interactive Roadmap to Mastering Backend Engineering.</p>
+    </header>
 
     <div class="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="lg:flex lg:space-x-8">
-            <!-- Table of Contents (Sticky) -->
-            <nav id="toc" class="hidden lg:block w-64 shrink-0 sticky top-20 self-start">
-                <div class="space-y-4">
-                    <h3 class="font-semibold text-slate-900 text-lg">On this page</h3>
-                    <ul class="space-y-2 text-slate-500">
-                        <li><a href="#theory" class="toc-link block border-l-2 border-transparent pl-4 hover:text-cyan-600 hover:border-cyan-600 transition-colors duration-200">Core Theory</a></li>
-                        <li><a href="#visualization" class="toc-link block border-l-2 border-transparent pl-4 hover:text-cyan-600 hover:border-cyan-600 transition-colors duration-200">Interactive Visualization</a></li>
-                        <li><a href="#practice" class="toc-link block border-l-2 border-transparent pl-4 hover:text-cyan-600 hover:border-cyan-600 transition-colors duration-200">Coding Practice</a></li>
-                        <li><a href="#uml" class="toc-link block border-l-2 border-transparent pl-4 hover:text-cyan-600 hover:border-cyan-600 transition-colors duration-200">UML/Schema Task</a></li>
-                        <li><a href="#case-study" class="toc-link block border-l-2 border-transparent pl-4 hover:text-cyan-600 hover:border-cyan-600 transition-colors duration-200">Case Study</a></li>
-                        <li><a href="#quiz" class="toc-link block border-l-2 border-transparent pl-4 hover:text-cyan-600 hover:border-cyan-600 transition-colors duration-200">Knowledge Check</a></li>
-                        <li><a href="#challenge" class="toc-link block border-l-2 border-transparent pl-4 hover:text-cyan-600 hover:border-cyan-600 transition-colors duration-200">Self-Assessment</a></li>
-                    </ul>
-                </div>
-            </nav>
-
             <!-- Main Content -->
             <main class="flex-1 min-w-0">
+                <a href="lld_homepage.html" class="text-teal-600 hover:text-teal-800 font-semibold transition-colors duration-200 inline-flex items-center">
+                    <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path></svg>
+                    Return to Homepage
+                </a>
                 <article class="prose lg:prose-xl max-w-none">
                     <header class="mb-12">
                         <p class="text-base font-semibold text-cyan-600">OOP Foundations: Day 4</p>
@@ -549,14 +540,28 @@
 
                 </article>
             </main>
+            <!-- Table of Contents (Sticky) -->
+            <nav id="toc" class="hidden lg:block w-64 shrink-0 sticky top-20 self-start">
+                <div class="space-y-4">
+                    <h3 class="font-semibold text-slate-900 text-lg">On this page</h3>
+                    <ul class="space-y-2 text-slate-500">
+                        <li><a href="#theory" class="toc-link block border-l-2 border-transparent pl-4 hover:text-cyan-600 hover:border-cyan-600 transition-colors duration-200">Core Theory</a></li>
+                        <li><a href="#visualization" class="toc-link block border-l-2 border-transparent pl-4 hover:text-cyan-600 hover:border-cyan-600 transition-colors duration-200">Interactive Visualization</a></li>
+                        <li><a href="#practice" class="toc-link block border-l-2 border-transparent pl-4 hover:text-cyan-600 hover:border-cyan-600 transition-colors duration-200">Coding Practice</a></li>
+                        <li><a href="#uml" class="toc-link block border-l-2 border-transparent pl-4 hover:text-cyan-600 hover:border-cyan-600 transition-colors duration-200">UML/Schema Task</a></li>
+                        <li><a href="#case-study" class="toc-link block border-l-2 border-transparent pl-4 hover:text-cyan-600 hover:border-cyan-600 transition-colors duration-200">Case Study</a></li>
+                        <li><a href="#quiz" class="toc-link block border-l-2 border-transparent pl-4 hover:text-cyan-600 hover:border-cyan-600 transition-colors duration-200">Knowledge Check</a></li>
+                        <li><a href="#challenge" class="toc-link block border-l-2 border-transparent pl-4 hover:text-cyan-600 hover:border-cyan-600 transition-colors duration-200">Self-Assessment</a></li>
+                    </ul>
+                </div>
+            </nav>
         </div>
     </div>
     
-    <!-- FOOTER -->
-    <footer class="mt-20 py-8 bg-slate-100 border-t">
-        <div class="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8 text-center text-slate-500">
-            <p>&copy; 2025 OOP Foundations Learning Module. All rights reserved.</p>
-        </div>
+    <footer class="text-center mt-16 py-8 border-t border-slate-200">
+        <p class="text-slate-700 font-semibold">Low-Level Design Bootcamp</p>
+        <p class="text-sm text-slate-500 mt-2">A personalized learning roadmap curated by Mr. Mahesh Singare.</p>
+        <p class="text-xs text-slate-400 mt-4">&copy; 2025. All Rights Reserved.</p>
     </footer>
 
 <script>

--- a/day_5.html
+++ b/day_5.html
@@ -74,24 +74,20 @@
     </style>
 </head>
 <body class="bg-gray-50 text-gray-800">
-    <!-- Chosen Palette: "Academic Blue & Slate" -->
-    <!-- Application Structure Plan: A two-column educational document layout was chosen for optimal learning flow. A sticky Table of Contents (TOC) on the left provides persistent, easy navigation, allowing users to jump between complex topics without losing their place. The main content area on the right presents information sequentially, using cards, call-outs, and interactive elements (code copying, quizzes) to break down information into digestible chunks. This structure is superior to a dashboard because the content is narrative and meant to be consumed in a structured, though not strictly linear, order. User interaction is focused on learning and reinforcement rather than data exploration. -->
-    <!-- Visualization & Content Choices: Report Info: C# coding concepts. Goal: Educate developers. Presentation: The lesson uses formatted text, tables for comparison, and highlighted code blocks for practical examples. Interaction: Copy-to-clipboard buttons on code blocks reduce friction. An interactive quiz provides immediate feedback for knowledge retention. Justification: This multi-faceted approach caters to different learning styles—theoretical (text), comparative (tables), practical (code), and kinesthetic (quiz interaction). Library/Method: Vanilla JS for all interactivity and Prism.js for code syntax highlighting, which is crucial for readability. -->
-    <!-- CONFIRMATION: NO SVG graphics used. NO Mermaid JS used. -->
+    <header class="text-center mb-10">
+        <h2 id="greeting" class="text-xl text-slate-500">Good Evening!</h2>
+        <h1 class="text-4xl sm:text-5xl font-extrabold text-slate-800 mt-1 tracking-tight">Low-Level Design Bootcamp</h1>
+        <p class="mt-3 text-slate-500 max-w-xl mx-auto">Your 60-Day Interactive Roadmap to Mastering Backend Engineering.</p>
+    </header>
 
     <div class="container mx-auto px-4 py-8">
         <div class="lg:flex lg:space-x-8">
             
-            <aside class="w-full lg:w-1/4 mb-8 lg:mb-0">
-                <div class="sticky top-8">
-                    <h3 class="text-lg font-semibold text-gray-900 mb-4">On this page</h3>
-                    <nav id="toc" class="flex flex-col space-y-2">
-                    </nav>
-                </div>
-            </aside>
-
             <main class="w-full lg:w-3/4">
-                <div id="header-gap" class="h-16"></div>
+                <a href="lld_homepage.html" class="text-teal-600 hover:text-teal-800 font-semibold transition-colors duration-200 inline-flex items-center">
+                    <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path></svg>
+                    Return to Homepage
+                </a>
 
                 <article class="prose max-w-none">
                     <section id="introduction" class="scroll-mt-20 space-y-4">
@@ -566,6 +562,13 @@ public class Program
                 </article>
 
             </main>
+            <aside class="w-full lg:w-1/4 mb-8 lg:mb-0">
+                <div class="sticky top-8">
+                    <h3 class="text-lg font-semibold text-gray-900 mb-4">On this page</h3>
+                    <nav id="toc" class="flex flex-col space-y-2">
+                    </nav>
+                </div>
+            </aside>
         </div>
     </div>
     
@@ -585,11 +588,10 @@ public class Program
     </div>
 
 
-    <footer class="bg-gray-800 text-white mt-16">
-        <div class="container mx-auto px-4 py-6 text-center">
-            <p>&copy; 2025 OOP Foundations. All rights reserved.</p>
-            <p>A Self-Contained Learning Module</p>
-        </div>
+    <footer class="text-center mt-16 py-8 border-t border-slate-200">
+        <p class="text-slate-700 font-semibold">Low-Level Design Bootcamp</p>
+        <p class="text-sm text-slate-500 mt-2">A personalized learning roadmap curated by Mr. Mahesh Singare.</p>
+        <p class="text-xs text-slate-400 mt-4">&copy; 2025. All Rights Reserved.</p>
     </footer>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js"></script>

--- a/day_6.html
+++ b/day_6.html
@@ -9,15 +9,6 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Roboto+Mono:wght@400;500&display=swap" rel="stylesheet">
-    <!-- Chosen Palette: "Crisp & Clean" - A bright white background with dark sienna text for maximum contrast and readability, accented with teal and sienna for key elements. -->
-    <!-- Application Structure Plan: A two-column layout is chosen for optimal learning ergonomics. A sticky Table of Contents (ToC) on the left provides constant, easy navigation, allowing users to jump between sections or track their progress. The main content area on the right flows logically from theory to practice, mimicking a well-structured textbook chapter. This design supports both linear learning and quick reference, making the complex information highly consumable and user-friendly. Key interactions include copy-to-clipboard for code, an interactive quiz for knowledge reinforcement, and toggleable solutions for self-assessment. -->
-    <!-- Visualization & Content Choices: 
-        - Report Info: UML Diagram for IPaymentProcessor. Goal: Organize/Structure. Viz/Presentation: HTML/CSS diagram. Interaction: Static visual reference. Justification: Avoids external libraries/SVG, directly renders the required structural relationship. Method: Styled divs.
-        - Report Info: Factory Pattern concept. Goal: Explain a process. Viz/Presentation: Bar Chart. Interaction: Hover tooltips. Justification: A Chart.js bar chart visually represents the Factory "delegating" tasks to different classes, making an abstract concept more concrete. Library: Chart.js.
-        - Report Info: Interface implementation concept. Goal: Explain a relationship. Viz/Presentation: Interactive Canvas Diagram. Interaction: Animated elements. Justification: A simple animation dynamically shows how different classes can "plug into" a common interface, illustrating polymorphism and contracts visually. Method: Vanilla JS Canvas API.
-        - Report Info: Coding problems and solutions. Goal: Inform/Educate. Viz/Presentation: Styled code blocks. Interaction: Copy-to-clipboard button. Justification: Essential for a coding tutorial, improves user experience by simplifying code transfer. Method: Vanilla JS.
-    -->
-    <!-- CONFIRMATION: NO SVG graphics used. NO Mermaid JS used. -->
     <style>
         body {
             font-family: 'Inter', sans-serif;
@@ -53,8 +44,6 @@
             font-family: 'Roboto Mono', monospace;
             font-size: 0.9em;
         }
-
-        /* Syntax Highlighting Tokens */
         .token.keyword { color: #569CD6; }
         .token.type { color: #4EC9B0; }
         .token.string { color: #CE9178; }
@@ -63,8 +52,6 @@
         .token.number { color: #B5CEA8; }
         .token.punctuation { color: #D4D4D4; }
         .token.variable { color: #9CDCFE; }
-
-        /* Button Styles */
         .btn {
             display: inline-block;
             font-weight: 600;
@@ -86,7 +73,7 @@
             position: absolute;
             top: 0.75rem;
             right: 0.75rem;
-            background-color: #4A5568; /* gray-600 */
+            background-color: #4A5568;
             color: white;
             border: none;
             padding: 0.25rem 0.5rem;
@@ -98,10 +85,8 @@
             opacity: 1;
         }
         .copy-btn:hover {
-            background-color: #2D3748; /* gray-800 */
+            background-color: #2D3748;
         }
-
-        /* TOC Styles */
         .toc-link {
             transition: all 0.2s ease-in-out;
             border-left: 2px solid transparent;
@@ -115,8 +100,6 @@
             border-left-color: #C06A47;
             font-weight: 700;
         }
-
-        /* General Prose & Layout */
         .prose-custom { max-width: 80ch; }
         .prose-custom h2 { margin-top: 2.5em; margin-bottom: 1em; }
         .prose-custom h3 { margin-top: 2em; margin-bottom: 0.8em; }
@@ -127,12 +110,9 @@
             padding: 1rem;
             border-radius: 0.25rem;
         }
-        
-        /* Quiz Styles */
         .quiz-option { transition: background-color 0.2s; }
         .quiz-option.correct { background-color: #C6F6D5; border-color: #38A169; }
         .quiz-option.incorrect { background-color: #FED7D7; border-color: #E53E3E; }
-        
         .shadow-sm { box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05); }
         .bg-white { background-color: #FFFFFF; }
         .border, .border-t { border-color: #e5e7eb; }
@@ -140,18 +120,38 @@
 </head>
 <body class="antialiased">
 
-    <!-- Custom Header Placeholder -->
-    <div id="custom-header-placeholder" class="h-16"></div>
+    <!-- Header -->
+    <header class="bg-white shadow-md fixed top-0 left-0 right-0 z-50">
+        <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex justify-between items-center py-3">
+                <div class="text-2xl font-bold text-sienna-800">
+                    <a href="lld_homepage.html">OOP Foundations</a>
+                </div>
+                <nav class="hidden md:flex space-x-4">
+                    <a href="day_1.html" class="text-gray-600 hover:text-teal-600 transition">Day 1</a>
+                    <a href="day_2.html" class="text-gray-600 hover:text-teal-600 transition">Day 2</a>
+                    <a href="day_3.html" class="text-gray-600 hover:text-teal-600 transition">Day 3</a>
+                    <a href="day_4.html" class="text-gray-600 hover:text-teal-600 transition">Day 4</a>
+                    <a href="day_5.html" class="text-gray-600 hover:text-teal-600 transition">Day 5</a>
+                    <a href="day_6.html" class="font-bold text-teal-600">Day 6</a>
+                    <a href="day_7.html" class="text-gray-600 hover:text-teal-600 transition">Day 7</a>
+                </nav>
+                <div class="hidden md:flex">
+                    <a href="lld_homepage.html" class="btn btn-primary">Return to Homepage</a>
+                </div>
+            </div>
+        </div>
+    </header>
 
-    <div class="container mx-auto px-4 sm:px-6 lg:px-8">
-        <header class="py-8 text-center">
-            <h1 class="text-4xl md:text-5xl font-bold tracking-tight text-sienna-800">OOP Foundations</h1>
-            <p class="mt-4 text-xl text-gray-600">Day 6: Interfaces & Partial Classes</p>
-        </header>
+    <main class="container mx-auto px-4 sm:px-6 lg:px-8 pt-24">
+        <div class="text-center mb-12">
+            <h1 class="text-4xl md:text-5xl font-bold tracking-tight text-sienna-800">Day 6: Interfaces & Partial Classes</h1>
+            <p class="mt-4 text-xl text-gray-600">Exploring contracts and code organization in C# for building flexible and maintainable systems.</p>
+        </div>
 
-        <div class="flex flex-col lg:flex-row lg:space-x-12">
+        <div class="flex flex-col lg:flex-row-reverse lg:space-x-reverse lg:space-x-12">
             <!-- Sticky Table of Contents -->
-            <aside class="w-full lg:w-1/4 lg:sticky lg:top-8 self-start mb-12 lg:mb-0">
+            <aside class="w-full lg:w-1/4 lg:sticky lg:top-24 self-start mb-12 lg:mb-0">
                 <div class="p-4 rounded-lg bg-white shadow-sm border">
                     <h3 class="text-lg font-semibold mb-4">On This Page</h3>
                     <nav id="toc-nav" class="flex flex-col space-y-2">
@@ -166,7 +166,7 @@
             </aside>
 
             <!-- Main Content -->
-            <main class="w-full lg:w-3/4 prose-custom">
+            <div class="w-full lg:w-3/4 prose-custom">
                 <section id="theory" class="scroll-mt-20">
                     <h2 class="text-3xl font-bold border-b pb-2">✅ Theory Topics</h2>
                     <p>Today, we dive into two powerful C# features that promote flexible and maintainable code: Interfaces and Partial Classes. Interfaces define contracts that classes must adhere to, enabling polymorphism and decoupling. Partial classes allow a single class definition to be split across multiple files, which is invaluable for code organization and working with auto-generated code.</p>
@@ -735,14 +735,17 @@
                         </div>
                     </div>
                 </section>
-            </main>
+            </div>
         </div>
-    </div>
+    </main>
 
     <footer class="mt-16 py-8 bg-white border-t">
-        <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center text-gray-500">
-            <p>&copy; 2025 OOP Foundations. All Rights Reserved.</p>
-            <p class="text-sm mt-1">A self-contained learning module.</p>
+        <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
+            <div class="flex justify-center mb-4">
+                <a href="lld_homepage.html" class="btn btn-primary">Return to Homepage</a>
+            </div>
+            <p class="text-gray-500">&copy; 2025 OOP Foundations. All Rights Reserved.</p>
+            <p class="text-sm mt-1 text-gray-500">A self-contained learning module.</p>
         </div>
     </footer>
 
@@ -1057,4 +1060,3 @@
     </script>
 </body>
 </html>
-

--- a/day_7.html
+++ b/day_7.html
@@ -60,28 +60,20 @@
     </style>
 </head>
 <body class="bg-slate-50">
+    <header class="text-center mb-10">
+        <h2 id="greeting" class="text-xl text-slate-500">Good Evening!</h2>
+        <h1 class="text-4xl sm:text-5xl font-extrabold text-slate-800 mt-1 tracking-tight">Low-Level Design Bootcamp</h1>
+        <p class="mt-3 text-slate-500 max-w-xl mx-auto">Your 60-Day Interactive Roadmap to Mastering Backend Engineering.</p>
+    </header>
 
     <div class="max-w-screen-xl mx-auto">
         <div class="flex flex-col md:flex-row">
-            <!-- Sidebar Navigation -->
-            <aside class="w-full md:w-64 lg:w-72 bg-white md:h-screen md:sticky md:top-0 border-b md:border-b-0 md:border-r border-slate-200">
-                <div class="p-4">
-                    <h2 class="text-lg font-bold text-indigo-600">Architect's Toolkit</h2>
-                    <p class="text-sm text-slate-500">Static Classes & Records</p>
-                </div>
-                <nav id="sidebar-nav" class="flex flex-col px-4 pb-4">
-                    <a href="#section1" class="nav-link text-slate-600 hover:bg-slate-100 rounded-md px-3 py-2 transition-colors duration-150 text-sm">1. Static Classes</a>
-                    <a href="#section2" class="nav-link text-slate-600 hover:bg-slate-100 rounded-md px-3 py-2 transition-colors duration-150 text-sm">2. C# Records</a>
-                    <a href="#section3" class="nav-link text-slate-600 hover:bg-slate-100 rounded-md px-3 py-2 transition-colors duration-150 text-sm">3. Advanced Topics</a>
-                    <a href="#section4" class="nav-link text-slate-600 hover:bg-slate-100 rounded-md px-3 py-2 transition-colors duration-150 text-sm">4. Coding Practice</a>
-                    <a href="#section5" class="nav-link text-slate-600 hover:bg-slate-100 rounded-md px-3 py-2 transition-colors duration-150 text-sm">5. UML Modeling</a>
-                    <a href="#section6" class="nav-link text-slate-600 hover:bg-slate-100 rounded-md px-3 py-2 transition-colors duration-150 text-sm">6. Case Study</a>
-                    <a href="#section7" class="nav-link text-slate-600 hover:bg-slate-100 rounded-md px-3 py-2 transition-colors duration-150 text-sm">7. Knowledge Assessment</a>
-                </nav>
-            </aside>
-
             <!-- Main Content -->
             <main class="flex-1 p-6 sm:p-8 lg:p-12">
+                <a href="lld_homepage.html" class="text-teal-600 hover:text-teal-800 font-semibold transition-colors duration-200 inline-flex items-center">
+                    <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path></svg>
+                    Return to Homepage
+                </a>
                 <header class="mb-12">
                     <h1 class="text-4xl font-extrabold tracking-tight text-slate-900">OOP Foundations, Day 7: Static Classes & Records</h1>
                     <p class="mt-2 text-lg text-slate-600">An interactive guide to the architect's toolkit for utility and data patterns in C#.</p>
@@ -343,8 +335,29 @@ public void HandleRequest()
 
                 </div>
             </main>
+            <!-- Sidebar Navigation -->
+            <aside class="w-full md:w-64 lg:w-72 bg-white md:h-screen md:sticky md:top-0 border-b md:border-b-0 md:border-r border-slate-200">
+                <div class="p-4">
+                    <h2 class="text-lg font-bold text-indigo-600">Architect's Toolkit</h2>
+                    <p class="text-sm text-slate-500">Static Classes & Records</p>
+                </div>
+                <nav id="sidebar-nav" class="flex flex-col px-4 pb-4">
+                    <a href="#section1" class="nav-link text-slate-600 hover:bg-slate-100 rounded-md px-3 py-2 transition-colors duration-150 text-sm">1. Static Classes</a>
+                    <a href="#section2" class="nav-link text-slate-600 hover:bg-slate-100 rounded-md px-3 py-2 transition-colors duration-150 text-sm">2. C# Records</a>
+                    <a href="#section3" class="nav-link text-slate-600 hover:bg-slate-100 rounded-md px-3 py-2 transition-colors duration-150 text-sm">3. Advanced Topics</a>
+                    <a href="#section4" class="nav-link text-slate-600 hover:bg-slate-100 rounded-md px-3 py-2 transition-colors duration-150 text-sm">4. Coding Practice</a>
+                    <a href="#section5" class="nav-link text-slate-600 hover:bg-slate-100 rounded-md px-3 py-2 transition-colors duration-150 text-sm">5. UML Modeling</a>
+                    <a href="#section6" class="nav-link text-slate-600 hover:bg-slate-100 rounded-md px-3 py-2 transition-colors duration-150 text-sm">6. Case Study</a>
+                    <a href="#section7" class="nav-link text-slate-600 hover:bg-slate-100 rounded-md px-3 py-2 transition-colors duration-150 text-sm">7. Knowledge Assessment</a>
+                </nav>
+            </aside>
         </div>
     </div>
+    <footer class="text-center mt-16 py-8 border-t border-slate-200">
+        <p class="text-slate-700 font-semibold">Low-Level Design Bootcamp</p>
+        <p class="text-sm text-slate-500 mt-2">A personalized learning roadmap curated by Mr. Mahesh Singare.</p>
+        <p class="text-xs text-slate-400 mt-4">&copy; 2025. All Rights Reserved.</p>
+    </footer>
 
 <script>
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
This commit applies a consistent look and feel to all `day_*.html` pages (from day_1.html to day_7.html).

The following changes were made to each file:
- Replaced the existing header with a new standardized header that includes navigation to all day pages.
- Replaced the existing footer with a new standardized footer.
- Added a "Return to Homepage" button to the header and footer for easier navigation.
- Moved the Table of Contents (TOC) to the right side of the page for a consistent two-column layout.