### PR TITLE
refactor: Standardize layout for all day pages

### DIFF
--- a/day_1.html
+++ b/day_1.html
@@ -1,70 +1,155 @@
+<!DOCTYPE html>
 <html lang="en" class="scroll-smooth">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>OOP Foundations: Day 1 - Intro, Encapsulation & Abstraction</title>
-    <!-- Chosen Palette: Light Slate & Soft Indigo -->
-    <!-- Application Structure Plan: A single-page educational module with a two-column layout. The left column features a sticky table of contents for easy navigation through the lesson's sections. The right column contains the main, scrollable content. This structure was chosen because it mirrors a textbook chapter's flow, which is ideal for learning. The user can either progress linearly by scrolling or jump to specific topics like Theory, Practice, UML Design, or the interactive Quiz. This non-linear access via the sticky nav empowers users to learn at their own pace and revisit sections easily, enhancing usability for a dense technical topic. -->
-    <!-- Visualization & Content Choices: 
-        - Theory (Objects, Classes, etc.): Goal: Inform. Method: Styled text blocks and syntax-highlighted code snippets. Interaction: Copy-to-clipboard button. Justification: Provides clear, readable explanations and makes code easily accessible.
-        - Encapsulation vs. Abstraction: Goal: Compare. Method: HTML table. Interaction: None. Justification: A table offers the most direct and effective side-by-side comparison.
-        - UML/Sequence Diagrams: Goal: Organize. Method: Custom HTML/CSS divs and flexbox to simulate diagrams. Interaction: None. Justification: This approach visually represents complex structures without using forbidden SVG/image files, keeping the app self-contained.
-        - Interactive Quiz & Challenge: Goal: Assess & Apply. Method: JS-powered quiz with instant feedback and a revealable solution for the challenge. Interaction: Click to answer/reveal. Justification: Active recall and self-assessment are powerful learning tools; this interactivity makes the learning process more engaging and effective.
-    -->
-    <!-- CONFIRMATION: NO SVG graphics used. NO Mermaid JS used. -->
+    <title>Day 1: Intro, Encapsulation & Abstraction - OOP Foundations</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/atom-one-dark.min.css">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Roboto+Mono:wght@400;500&display=swap" rel="stylesheet">
     <style>
-        body { font-family: 'Inter', sans-serif; background-color: #f1f5f9; color: #334155; }
-        .toc-link.active { color: #6366f1; font-weight: 600; border-left-color: #6366f1; transform: translateX(4px); }
-        .toc-link { transition: all 0.2s ease-in-out; }
-        .code-block { position: relative; }
-        .copy-btn { position: absolute; top: 0.75rem; right: 0.75rem; background-color: #334155; color: #e2e8f0; padding: 0.25rem 0.75rem; border-radius: 0.375rem; font-size: 0.875rem; font-weight: 500; cursor: pointer; opacity: 0; transition: all 0.2s; border: 1px solid #475569; }
-        .code-block:hover .copy-btn { opacity: 1; }
-        .copy-btn:hover { background-color: #475569; }
-        .quiz-option { cursor: pointer; transition: all 0.2s ease-in-out; }
-        .quiz-option:hover { background-color: #eef2ff; border-color: #818cf8; transform: scale(1.02); }
-        .quiz-option.correct { background-color: #dcfce7; border-color: #22c55e; color: #15803d; font-weight: 500; }
-        .quiz-option.incorrect { background-color: #fee2e2; border-color: #ef4444; color: #b91c1c; font-weight: 500; }
-        .quiz-option.reveal { border-color: #22c55e !important; }
-        .solution-toggle { cursor: pointer; }
-        .uml-class, .uml-actor, .uml-obj, .seq-obj { border: 2px solid #94a3b8; padding: 0.75rem; text-align: center; background-color: #f8fafc; border-radius: 0.5rem; box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05); }
-        .uml-class .title { font-weight: 700; color: #1e293b; border-bottom: 2px solid #cbd5e1; padding-bottom: 0.5rem; margin-bottom: 0.5rem; }
-        .uml-connector { position: relative; display: flex; align-items: center; justify-content: center; margin: 1rem 0; height: 2px; background-color: #94a3b8; }
-        .uml-connector-v { width: 2px; background-color: #94a3b8; margin: 0 auto; }
-        .uml-label { position: absolute; background-color: #f1f5f9; padding: 0 0.5rem; color: #475569; font-size: 0.875rem; font-weight: 500; }
-        .seq-line { border-left: 2px dashed #94a3b8; height: 100%; position: absolute; left: 50%; transform: translateX(-1px); }
-        .seq-arrow { width: 100%; height: 2px; background-color: #3b82f6; position: relative; }
-        .seq-arrow::after { content: '▶'; position: absolute; right: -4px; top: 50%; transform: translateY(-50%); color: #3b82f6; font-size: 1.1rem; }
-        .seq-arrow-return { background-color: #64748b; border-top: 2px dashed #64748b; }
-        .seq-arrow-return::after { content: '◀'; color: #64748b; font-size: 1.1rem; left: -4px; }
-
-        pre code.hljs { border-radius: 0.5rem; padding: 1.25rem !important; }
-        .content-card { background-color: white; border-radius: 0.75rem; border: 1px solid #e2e8f0; box-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.05); overflow: hidden; }
+        body {
+            font-family: 'Inter', sans-serif;
+            background-color: #FFFFFF;
+            color: #3D352E;
+        }
+        h1, h2, h3, h4, h5, h6 {
+            font-family: 'Inter', sans-serif;
+            font-weight: 700;
+        }
+        pre {
+            background-color: #1E1E1E;
+            color: #D4D4D4;
+            font-family: 'Roboto Mono', monospace;
+            border-radius: 0.5rem;
+            padding: 1.25rem;
+            position: relative;
+            overflow-x: auto;
+            border: 1px solid #3a404a;
+        }
+        pre code {
+            background-color: transparent !important;
+            color: inherit;
+            padding: 0;
+            font-size: inherit;
+            border-radius: 0;
+        }
+        .prose-custom :not(pre) > code {
+            background-color: #F3F4F6;
+            color: #C06A47;
+            padding: 0.2em 0.4em;
+            border-radius: 3px;
+            font-family: 'Roboto Mono', monospace;
+            font-size: 0.9em;
+        }
+        .btn {
+            display: inline-block;
+            font-weight: 600;
+            padding: 0.5rem 1rem;
+            border-radius: 0.375rem;
+            transition: all 0.2s ease-in-out;
+            cursor: pointer;
+            text-align: center;
+        }
+        .btn-primary {
+            background-color: #C06A47; /* Sienna */
+            color: #FFFFFF;
+            border: 1px solid transparent;
+        }
+        .btn-primary:hover {
+            background-color: #A95A3A; /* Darker Sienna */
+        }
+        .copy-btn {
+            position: absolute;
+            top: 0.75rem;
+            right: 0.75rem;
+            background-color: #4A5568;
+            color: white;
+            border: none;
+            padding: 0.25rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            opacity: 0;
+            transition: all 0.2s;
+        }
+        pre:hover .copy-btn {
+            opacity: 1;
+        }
+        .copy-btn:hover {
+            background-color: #2D3748;
+        }
+        .toc-link {
+            transition: all 0.2s ease-in-out;
+            border-left: 2px solid transparent;
+        }
+        .toc-link:hover {
+            color: #3E8A86; /* Teal */
+            border-left-color: #3E8A86;
+        }
+        .toc-link.active {
+            color: #C06A47; /* Sienna */
+            border-left-color: #C06A47;
+            font-weight: 700;
+        }
+        .prose-custom { max-width: 80ch; }
+        .prose-custom h2 { margin-top: 2.5em; margin-bottom: 1em; }
+        .prose-custom h3 { margin-top: 2em; margin-bottom: 0.8em; }
+        .prose-custom p, .prose-custom ul, .prose-custom ol { line-height: 1.7; }
+        .shadow-sm { box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05); }
+        .bg-white { background-color: #FFFFFF; }
+        .border, .border-t { border-color: #e5e7eb; }
     </style>
 </head>
 <body class="antialiased">
-    <header class="text-center mb-10">
-            <h2 id="greeting" class="text-xl text-slate-500">Good Evening!</h2>
-            <h1 class="text-4xl sm:text-5xl font-extrabold text-slate-800 mt-1 tracking-tight">Low-Level Design Bootcamp</h1>
-            <p class="mt-3 text-slate-500 max-w-xl mx-auto">Your 60-Day Interactive Roadmap to Mastering Backend Engineering.</p>
-        </header>
-        
 
-    <div class="container mx-auto px-4 sm:px-6 lg:px-8 mt-8">
-        <div class="flex flex-col md:flex-row md:space-x-8 lg:space-x-12">
-            <main class="w-full md:w-3/4 lg:w-4/5 mt-8 md:mt-0">
-                <a href="lld_homepage.html" class="text-teal-600 hover:text-teal-800 font-semibold transition-colors duration-200 inline-flex items-center">
-                    <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path></svg>
-                    Return to Homepage
-                </a>
-                <div class="mb-12">
-                    <h1 class="text-4xl font-extrabold text-slate-900 tracking-tight">OOP Foundations: Day 1</h1>
-                    <p class="mt-2 text-xl text-slate-600">An Introduction to Encapsulation & Abstraction in C#</p>
+    <!-- Header -->
+    <header class="bg-white shadow-md fixed top-0 left-0 right-0 z-50">
+        <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex justify-between items-center py-3">
+                <div class="text-2xl font-bold text-sienna-800">
+                    <a href="roadmap.html">OOP Foundations</a>
                 </div>
-                
+                <nav class="hidden md:flex space-x-4">
+                    <a href="day_1.html" class="font-bold text-teal-600">Day 1</a>
+                    <a href="day_2.html" class="text-gray-600 hover:text-teal-600 transition">Day 2</a>
+                    <a href="day_3.html" class="text-gray-600 hover:text-teal-600 transition">Day 3</a>
+                    <a href="day_4.html" class="text-gray-600 hover:text-teal-600 transition">Day 4</a>
+                    <a href="day_5.html" class="text-gray-600 hover:text-teal-600 transition">Day 5</a>
+                    <a href="day_6.html" class="text-gray-600 hover:text-teal-600 transition">Day 6</a>
+                    <a href="day_7.html" class="text-gray-600 hover:text-teal-600 transition">Day 7</a>
+                </nav>
+                <!-- Return to Homepage button removed from here -->
+            </div>
+        </div>
+    </header>
+
+    <main class="container mx-auto px-4 sm:px-6 lg:px-8 pt-24">
+        <div class="flex justify-between items-center mb-12">
+            <div class="text-center">
+                <h1 class="text-4xl md:text-5xl font-bold tracking-tight text-sienna-800">Day 1: Intro, Encapsulation & Abstraction</h1>
+                <p class="mt-4 text-xl text-gray-600">An Introduction to Encapsulation & Abstraction in C#</p>
+            </div>
+            <a href="roadmap.html" class="btn btn-primary whitespace-nowrap">Return to Homepage</a>
+        </div>
+
+        <div class="flex flex-col lg:flex-row-reverse lg:space-x-reverse lg:space-x-12">
+            <aside class="w-full lg:w-1/4 lg:sticky lg:top-24 self-start mb-12 lg:mb-0">
+                <div class="p-4 rounded-lg bg-white shadow-sm border">
+                    <h3 class="text-lg font-semibold mb-4">On This Page</h3>
+                    <nav id="toc-nav" class="flex flex-col space-y-2">
+                        <a href="#theory" class="toc-link pl-2 text-gray-600">Theory Deep Dive</a>
+                        <a href="#practice" class="toc-link pl-2 text-gray-600">Coding Practice</a>
+                        <a href="#problems" class="toc-link pl-2 text-gray-600">Problem Solving</a>
+                        <a href="#uml" class="toc-link pl-2 text-gray-600">UML/Schema Design</a>
+                        <a href="#case-study" class="toc-link pl-2 text-gray-600">Case Study</a>
+                        <a href="#quiz" class="toc-link pl-2 text-gray-600">Knowledge Check</a>
+                        <a href="#challenge" class="toc-link pl-2 text-gray-600">Self-Assessment</a>
+                    </nav>
+                </div>
+            </aside>
+
+            <div class="w-full lg:w-3/4 prose-custom">
                 <section id="theory" class="scroll-mt-24 space-y-12">
                     <h2 class="text-3xl font-bold text-slate-900 border-b-2 border-slate-200 pb-3">Theory Deep Dive</h2>
                     
@@ -693,170 +778,50 @@ public class VendingMachine
                         </div>
                      </article>
                 </section>
-            </main>
-            <aside class="w-full md:w-1/4 lg:w-1/5">
-                <nav id="toc" class="sticky top-24">
-                    <h3 class="font-bold text-slate-900 mb-4 text-lg">Table of Contents</h3>
-                    <ul class="space-y-2">
-                        <li><a href="#theory" class="toc-link block border-l-4 border-transparent pl-4 text-slate-600 hover:text-indigo-600 hover:border-indigo-300">Theory Deep Dive</a></li>
-                        <li><a href="#practice" class="toc-link block border-l-4 border-transparent pl-4 text-slate-600 hover:text-indigo-600 hover:border-indigo-300">Coding Practice</a></li>
-                        <li><a href="#problems" class="toc-link block border-l-4 border-transparent pl-4 text-slate-600 hover:text-indigo-600 hover:border-indigo-300">Problem Solving</a></li>
-                        <li><a href="#uml" class="toc-link block border-l-4 border-transparent pl-4 text-slate-600 hover:text-indigo-600 hover:border-indigo-300">UML/Schema Design</a></li>
-                        <li><a href="#case-study" class="toc-link block border-l-4 border-transparent pl-4 text-slate-600 hover:text-indigo-600 hover:border-indigo-300">Case Study</a></li>
-                        <li><a href="#quiz" class="toc-link block border-l-4 border-transparent pl-4 text-slate-600 hover:text-indigo-600 hover:border-indigo-300">Knowledge Check</a></li>
-                        <li><a href="#challenge" class="toc-link block border-l-4 border-transparent pl-4 text-slate-600 hover:text-indigo-600 hover:border-indigo-300">Self-Assessment</a></li>
-                    </ul>
-                </nav>
-            </aside>
+            </div>
         </div>
-    </div>
+    </main>
 
-    <footer class="text-center mt-16 py-8 border-t border-slate-200">
-        <p class="text-slate-700 font-semibold">Low-Level Design Bootcamp</p>
-        <p class="text-sm text-slate-500 mt-2">A personalized learning roadmap curated by Mr. Mahesh Singare.</p>
-        <p class="text-xs text-slate-400 mt-4">&copy; 2025. All Rights Reserved.</p>
+    <footer class="mt-16 py-8 bg-white border-t">
+        <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
+            <div class="flex justify-center mb-4">
+                <a href="roadmap.html" class="btn btn-primary">Return to Homepage</a>
+            </div>
+            <p class="text-gray-500">&copy; 2025 OOP Foundations. All Rights Reserved.</p>
+            <p class="text-sm mt-1 text-gray-500">A self-contained learning module.</p>
+        </div>
     </footer>
 
     <script>
-    document.addEventListener('DOMContentLoaded', () => {
-        hljs.highlightAll();
-
-        const tocLinks = document.querySelectorAll('.toc-link');
-        const sections = document.querySelectorAll('main section');
-
-        const observerOptions = {
-            root: null,
-            rootMargin: '0px',
-            threshold: 0.3
-        };
-
-        const observer = new IntersectionObserver((entries, obs) => {
-            entries.forEach(entry => {
-                if(entry.isIntersecting) {
-                    tocLinks.forEach(link => {
-                        link.classList.remove('active');
-                        if(link.getAttribute('href').substring(1) === entry.target.id) {
-                            link.classList.add('active');
-                        }
+        document.addEventListener('DOMContentLoaded', function () {
+            // --- Copy-to-Clipboard ---
+            document.querySelectorAll('.copy-btn').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    const code = btn.parentElement.querySelector('pre code').innerText;
+                    navigator.clipboard.writeText(code).then(() => {
+                        btn.textContent = 'Copied!';
+                        setTimeout(() => btn.textContent = 'Copy', 2000);
                     });
-                }
-            });
-        }, observerOptions);
-
-        sections.forEach(section => {
-            observer.observe(section);
-        });
-
-        const copyButtons = document.querySelectorAll('.copy-btn');
-        copyButtons.forEach(button => {
-            button.addEventListener('click', () => {
-                const code = button.previousElementSibling.textContent;
-                const tempTextArea = document.createElement('textarea');
-                tempTextArea.value = code;
-                document.body.appendChild(tempTextArea);
-                tempTextArea.select();
-                try {
-                    document.execCommand('copy');
-                    button.textContent = 'Copied!';
-                } catch (err) {
-                    button.textContent = 'Error';
-                    console.error('Failed to copy text: ', err);
-                }
-                document.body.removeChild(tempTextArea);
-                setTimeout(() => {
-                    button.textContent = 'Copy';
-                }, 2000);
-            });
-        });
-
-        const solutionToggle = document.getElementById('solution-toggle');
-        const solutionContent = document.getElementById('solution-content');
-        const solutionArrow = document.getElementById('solution-arrow');
-        solutionToggle.addEventListener('click', () => {
-            const isHidden = solutionContent.classList.contains('hidden');
-            solutionContent.classList.toggle('hidden');
-            solutionArrow.style.transform = isHidden ? 'rotate(90deg)' : 'rotate(0deg)';
-        });
-
-        const quizData = [
-            {
-                question: "Which principle is primarily concerned with hiding data and restricting access?",
-                options: ["Abstraction", "Inheritance", "Encapsulation", "Polymorphism"],
-                answer: "Encapsulation"
-            },
-            {
-                question: "What is the default access modifier for a class member in C# if none is specified?",
-                options: ["public", "internal", "protected", "private"],
-                answer: "private"
-            },
-            {
-                question: "An `interface` in C# is a pure form of which OOP concept?",
-                options: ["Polymorphism", "Abstraction", "Encapsulation", "Inheritance"],
-                answer: "Abstraction"
-            },
-            {
-                question: "If a class `Dog` inherits from a class `Animal`, which access modifier allows members of `Animal` to be accessed in `Dog` but not from outside?",
-                options: ["private", "public", "internal", "protected"],
-                answer: "protected"
-            }
-        ];
-        
-        const quizContainer = document.getElementById('quiz-container');
-        const quizResults = document.getElementById('quiz-results');
-        let score = 0;
-        let questionsAnswered = 0;
-
-        quizData.forEach((q, index) => {
-            const questionElement = document.createElement('article');
-            questionElement.innerHTML = `
-                <h3 class="font-semibold text-slate-800 text-base">${index + 1}. ${q.question}</h3>
-                <div class="mt-4 space-y-3">
-                    ${q.options.map(opt => `<div class="quiz-option border-2 border-slate-200 rounded-md p-3 hover:bg-slate-50">${opt}</div>`).join('')}
-                </div>
-                <div class="quiz-feedback mt-3 text-sm font-medium hidden p-3 rounded-md"></div>
-            `;
-            quizContainer.appendChild(questionElement);
-
-            const options = questionElement.querySelectorAll('.quiz-option');
-            const feedback = questionElement.querySelector('.quiz-feedback');
-            
-            options.forEach(option => {
-                option.addEventListener('click', () => {
-                    if (questionElement.classList.contains('answered')) return;
-                    questionElement.classList.add('answered');
-                    questionsAnswered++;
-                    
-                    const selectedAnswer = option.textContent;
-                    const correctAnswer = q.answer;
-                    
-                    if (selectedAnswer === correctAnswer) {
-                        option.classList.add('correct');
-                        feedback.textContent = '✅ Correct!';
-                        feedback.classList.add('bg-green-50', 'text-green-700');
-                        score++;
-                    } else {
-                        option.classList.add('incorrect');
-                        feedback.textContent = `❌ Incorrect. The correct answer is "${correctAnswer}".`;
-                        feedback.classList.add('bg-red-50', 'text-red-700');
-                    }
-                    
-                    options.forEach(opt => {
-                        if (opt.textContent === correctAnswer) {
-                           opt.classList.add('reveal');
-                        }
-                    });
-
-                    feedback.classList.remove('hidden');
-
-                    if(questionsAnswered === quizData.length) {
-                        quizResults.textContent = `Quiz Complete! You scored ${score} out of ${quizData.length}.`;
-                        quizResults.classList.remove('hidden');
-                    }
                 });
             });
+
+            // --- Active TOC Link ---
+            const sections = document.querySelectorAll('main section');
+            const tocLinks = document.querySelectorAll('.toc-link');
+            const observer = new IntersectionObserver(entries => {
+                entries.forEach(entry => {
+                    if (entry.isIntersecting) {
+                        tocLinks.forEach(link => {
+                            link.classList.remove('active');
+                            if (link.getAttribute('href') === `#${entry.target.id}`) {
+                                link.classList.add('active');
+                            }
+                        });
+                    }
+                });
+            }, { rootMargin: '-40% 0px -60% 0px' });
+            sections.forEach(section => observer.observe(section));
         });
-    });
     </script>
 </body>
 </html>
-

--- a/day_2.html
+++ b/day_2.html
@@ -3,77 +3,154 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>OOP Day 2: Constructors, Static Members & Object Lifecycle</title>
+    <title>Day 2: Constructors, Static Members & Object Lifecycle - OOP Foundations</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Roboto+Mono:wght@400;500&display=swap" rel="stylesheet">
-    <!-- Chosen Palette: Slate & Sky -->
-    <!-- Application Structure Plan: A single-page, long-scroll educational module with a sticky left-hand Table of Contents for seamless navigation. The structure progresses logically from theory to practice, culminating in a case study and self-assessment. This linear-yet-navigable design is chosen because it mirrors a typical learning path, allowing users to either follow the lesson step-by-step or jump directly to sections for review, maximizing usability for both new learners and those revisiting concepts. -->
-    <!-- Visualization & Content Choices: Object Lifecycle -> Inform -> HTML/CSS Diagram -> Color highlighting on hover -> Simple, clear visual flow without external libraries. Static vs. Instance -> Compare -> HTML Table -> Clear side-by-side text -> Direct comparison for conceptual clarity. UML Diagrams (Logger, Parking Lot) -> Organize -> HTML/CSS Grid & Flexbox -> Styled divs and borders to mimic UML -> Adheres to no-SVG rule while visually representing class structures. Coding Problems/Case Study -> Apply -> Collapsible Code Blocks (HTML/JS) -> Show/Hide solutions -> Allows for self-paced learning and testing before viewing answers. CONFIRMING NO SVG/Mermaid used. -->
-    <!-- CONFIRMATION: NO SVG graphics used. NO Mermaid JS used. -->
     <style>
         body {
             font-family: 'Inter', sans-serif;
-            background-color: #f8fafc;
+            background-color: #FFFFFF;
+            color: #3D352E;
         }
-        pre, code {
+        h1, h2, h3, h4, h5, h6 {
+            font-family: 'Inter', sans-serif;
+            font-weight: 700;
+        }
+        pre {
+            background-color: #1E1E1E;
+            color: #D4D4D4;
             font-family: 'Roboto Mono', monospace;
-        }
-        .toc-link.active {
-            color: #0284c7;
-            font-weight: 600;
-            border-left-color: #0284c7;
-        }
-        .code-block {
+            border-radius: 0.5rem;
+            padding: 1.25rem;
             position: relative;
+            overflow-x: auto;
+            border: 1px solid #3a404a;
+        }
+        pre code {
+            background-color: transparent !important;
+            color: inherit;
+            padding: 0;
+            font-size: inherit;
+            border-radius: 0;
+        }
+        .prose-custom :not(pre) > code {
+            background-color: #F3F4F6;
+            color: #C06A47;
+            padding: 0.2em 0.4em;
+            border-radius: 3px;
+            font-family: 'Roboto Mono', monospace;
+            font-size: 0.9em;
+        }
+        .btn {
+            display: inline-block;
+            font-weight: 600;
+            padding: 0.5rem 1rem;
+            border-radius: 0.375rem;
+            transition: all 0.2s ease-in-out;
+            cursor: pointer;
+            text-align: center;
+        }
+        .btn-primary {
+            background-color: #C06A47; /* Sienna */
+            color: #FFFFFF;
+            border: 1px solid transparent;
+        }
+        .btn-primary:hover {
+            background-color: #A95A3A; /* Darker Sienna */
         }
         .copy-btn {
             position: absolute;
-            top: 0.5rem;
-            right: 0.5rem;
-            background-color: #475569;
+            top: 0.75rem;
+            right: 0.75rem;
+            background-color: #4A5568;
             color: white;
+            border: none;
             padding: 0.25rem 0.5rem;
             border-radius: 0.25rem;
             font-size: 0.75rem;
-            cursor: pointer;
             opacity: 0;
-            transition: opacity 0.2s ease-in-out;
+            transition: all 0.2s;
         }
-        .code-block:hover .copy-btn {
+        pre:hover .copy-btn {
             opacity: 1;
         }
-        .callout {
-            border-left: 4px solid #38bdf8;
-            background-color: #f0f9ff;
-            padding: 1rem;
-            margin: 1.5rem 0;
-            border-radius: 0 0.5rem 0.5rem 0;
+        .copy-btn:hover {
+            background-color: #2D3748;
         }
+        .toc-link {
+            transition: all 0.2s ease-in-out;
+            border-left: 2px solid transparent;
+        }
+        .toc-link:hover {
+            color: #3E8A86; /* Teal */
+            border-left-color: #3E8A86;
+        }
+        .toc-link.active {
+            color: #C06A47; /* Sienna */
+            border-left-color: #C06A47;
+            font-weight: 700;
+        }
+        .prose-custom { max-width: 80ch; }
+        .prose-custom h2 { margin-top: 2.5em; margin-bottom: 1em; }
+        .prose-custom h3 { margin-top: 2em; margin-bottom: 0.8em; }
+        .prose-custom p, .prose-custom ul, .prose-custom ol { line-height: 1.7; }
+        .shadow-sm { box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05); }
+        .bg-white { background-color: #FFFFFF; }
+        .border, .border-t { border-color: #e5e7eb; }
     </style>
 </head>
-<body class="text-slate-800">
-    <header class="text-center mb-10">
-        <h2 id="greeting" class="text-xl text-slate-500">Good Evening!</h2>
-        <h1 class="text-4xl sm:text-5xl font-extrabold text-slate-800 mt-1 tracking-tight">Low-Level Design Bootcamp</h1>
-        <p class="mt-3 text-slate-500 max-w-xl mx-auto">Your 60-Day Interactive Roadmap to Mastering Backend Engineering.</p>
+<body class="antialiased">
+
+    <!-- Header -->
+    <header class="bg-white shadow-md fixed top-0 left-0 right-0 z-50">
+        <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex justify-between items-center py-3">
+                <div class="text-2xl font-bold text-sienna-800">
+                    <a href="roadmap.html">OOP Foundations</a>
+                </div>
+                <nav class="hidden md:flex space-x-4">
+                    <a href="day_1.html" class="text-gray-600 hover:text-teal-600 transition">Day 1</a>
+                    <a href="day_2.html" class="font-bold text-teal-600">Day 2</a>
+                    <a href="day_3.html" class="text-gray-600 hover:text-teal-600 transition">Day 3</a>
+                    <a href="day_4.html" class="text-gray-600 hover:text-teal-600 transition">Day 4</a>
+                    <a href="day_5.html" class="text-gray-600 hover:text-teal-600 transition">Day 5</a>
+                    <a href="day_6.html" class="text-gray-600 hover:text-teal-600 transition">Day 6</a>
+                    <a href="day_7.html" class="text-gray-600 hover:text-teal-600 transition">Day 7</a>
+                </nav>
+                <!-- Return to Homepage button removed from here -->
+            </div>
+        </div>
     </header>
 
-    <div class="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-        <div class="lg:grid lg:grid-cols-12 lg:gap-8">
-            <!-- Main Content -->
-            <main class="lg:col-span-9">
-                <a href="lld_homepage.html" class="text-teal-600 hover:text-teal-800 font-semibold transition-colors duration-200 inline-flex items-center">
-                    <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path></svg>
-                    Return to Homepage
-                </a>
-                <div class="prose prose-slate max-w-none">
-                    <h1 class="text-4xl font-bold tracking-tight text-slate-900">OOP Foundations: Day 2</h1>
-                    <p class="text-xl text-slate-600 mt-2">Diving into Constructors, Static Members, and the Object Lifecycle.</p>
+    <main class="container mx-auto px-4 sm:px-6 lg:px-8 pt-24">
+        <div class="flex justify-between items-center mb-12">
+            <div class="text-center">
+                <h1 class="text-4xl md:text-5xl font-bold tracking-tight text-sienna-800">Day 2: Constructors, Static Members & Object Lifecycle</h1>
+                <p class="mt-4 text-xl text-gray-600">Diving into Constructors, Static Members, and the Object Lifecycle.</p>
+            </div>
+            <a href="roadmap.html" class="btn btn-primary whitespace-nowrap">Return to Homepage</a>
+        </div>
 
-                    <!-- Theory Topics Section -->
-                    <section id="theory" class="mt-16 scroll-mt-24">
+        <div class="flex flex-col lg:flex-row-reverse lg:space-x-reverse lg:space-x-12">
+            <aside class="w-full lg:w-1/4 lg:sticky lg:top-24 self-start mb-12 lg:mb-0">
+                <div class="p-4 rounded-lg bg-white shadow-sm border">
+                    <h3 class="text-lg font-semibold mb-4">On This Page</h3>
+                    <nav id="toc-nav" class="flex flex-col space-y-2">
+                        <a href="#theory" class="toc-link pl-2 text-gray-600">Theory Topics</a>
+                        <a href="#coding-practice" class="toc-link pl-2 text-gray-600">Coding Practice</a>
+                        <a href="#problems" class="toc-link pl-2 text-gray-600">Problems & Solutions</a>
+                        <a href="#uml-task" class="toc-link pl-2 text-gray-600">UML/Schema Task</a>
+                        <a href="#case-study" class="toc-link pl-2 text-gray-600">Case Study: Parking Lot</a>
+                        <a href="#knowledge-check" class="toc-link pl-2 text-gray-600">Knowledge Check</a>
+                        <a href="#self-assessment" class="toc-link pl-2 text-gray-600">Self-Assessment Challenge</a>
+                    </nav>
+                </div>
+            </aside>
+
+            <div class="w-full lg:w-3/4 prose-custom">
+                <section id="theory" class="mt-16 scroll-mt-24">
                         <h2 class="text-3xl font-semibold text-slate-900 border-b pb-2">✅ Theory Topics</h2>
                         <p class="mt-4 text-slate-600">This section breaks down the fundamental concepts of object creation, shared class members, and the journey of an object from birth to destruction. Understanding these pillars is crucial for writing robust and efficient object-oriented code.</p>
                         
@@ -980,117 +1057,49 @@ public static class ConnectionPoolDemo
                             </div>
                         </article>
                     </section>
-                </div>
-            </main>
+            </div>
         </div>
-    </div>
-    
-    <!-- Consistent Footer -->
-    <footer class="bg-slate-800 text-slate-400 mt-20">
-        <div class="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8 py-8 text-center">
-            <p>&copy; 2025 OOP Learning Modules. All rights reserved.</p>
-            <p class="text-xs mt-2">Built for an interactive learning experience.</p>
+    </main>
+
+    <footer class="mt-16 py-8 bg-white border-t">
+        <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
+            <div class="flex justify-center mb-4">
+                <a href="roadmap.html" class="btn btn-primary">Return to Homepage</a>
+            </div>
+            <p class="text-gray-500">&copy; 2025 OOP Foundations. All Rights Reserved.</p>
+            <p class="text-sm mt-1 text-gray-500">A self-contained learning module.</p>
         </div>
     </footer>
 
     <script>
         document.addEventListener('DOMContentLoaded', function () {
             // --- Copy-to-Clipboard ---
-            const allCopyButtons = document.querySelectorAll('.copy-btn');
-            allCopyButtons.forEach(btn => {
+            document.querySelectorAll('.copy-btn').forEach(btn => {
                 btn.addEventListener('click', () => {
                     const code = btn.parentElement.querySelector('pre code').innerText;
                     navigator.clipboard.writeText(code).then(() => {
                         btn.textContent = 'Copied!';
-                        setTimeout(() => {
-                            btn.textContent = 'Copy';
-                        }, 2000);
+                        setTimeout(() => btn.textContent = 'Copy', 2000);
                     });
                 });
             });
 
-            // --- Toggle Solutions ---
-            const allToggleButtons = document.querySelectorAll('.toggle-solution-btn');
-            allToggleButtons.forEach(btn => {
-                btn.addEventListener('click', () => {
-                    const content = btn.nextElementSibling;
-                    const isHidden = content.classList.contains('hidden');
-                    if (isHidden) {
-                        content.classList.remove('hidden');
-                        btn.textContent = btn.textContent.replace('Show', 'Hide');
-                    } else {
-                        content.classList.add('hidden');
-                        btn.textContent = btn.textContent.replace('Hide', 'Show');
-                    }
-                });
-            });
-
-            // --- Quiz Logic ---
-            const checkAnswersBtn = document.getElementById('check-answers-btn');
-            const quizAnswers = {
-                q1: 'b',
-                q2: 'c',
-                q3: 'c'
-            };
-            const quizFeedbackText = {
-                 q1: {
-                    b: 'Correct! The constructor\'s main role is to initialize an object.',
-                    incorrect: 'Incorrect. The constructor sets up the initial state of an object.'
-                },
-                q2: {
-                    c: 'Correct! Static members belong to the class, so there is only one copy regardless of the number of instances.',
-                    incorrect: 'Incorrect. Static fields are shared across all instances, so only one copy exists.'
-                },
-                q3: {
-                    c: 'Correct! Utility or helper methods that don\'t rely on instance state are perfect candidates for being static.',
-                    incorrect: 'Incorrect. TakeDamage, Send, and StartEngine all operate on the specific state of a particular object.'
-                }
-            };
-            
-            checkAnswersBtn.addEventListener('click', () => {
-                const questions = document.querySelectorAll('.quiz-question');
-                questions.forEach(question => {
-                    const qName = question.querySelector('input').name;
-                    const selected = question.querySelector(`input[name=${qName}]:checked`);
-                    const feedbackEl = question.querySelector('.quiz-feedback');
-                    
-                    feedbackEl.classList.remove('hidden', 'text-green-600', 'text-red-600');
-
-                    if (selected) {
-                        if (selected.value === quizAnswers[qName]) {
-                            feedbackEl.textContent = quizFeedbackText[qName][selected.value];
-                            feedbackEl.classList.add('text-green-600');
-                        } else {
-                            feedbackEl.textContent = quizFeedbackText[qName]['incorrect'];
-                            feedbackEl.classList.add('text-red-600');
-                        }
-                    } else {
-                        feedbackEl.textContent = 'Please select an answer.';
-                        feedbackEl.classList.add('text-yellow-600');
-                    }
-                });
-            });
-
-            // --- TOC Active State Scrolling ---
+            // --- Active TOC Link ---
             const sections = document.querySelectorAll('main section');
-            const tocLinks = document.querySelectorAll('#toc .toc-link');
-
-            const observer = new IntersectionObserver((entries) => {
+            const tocLinks = document.querySelectorAll('.toc-link');
+            const observer = new IntersectionObserver(entries => {
                 entries.forEach(entry => {
                     if (entry.isIntersecting) {
                         tocLinks.forEach(link => {
                             link.classList.remove('active');
-                            if (link.getAttribute('href').substring(1) === entry.target.id) {
+                            if (link.getAttribute('href') === `#${entry.target.id}`) {
                                 link.classList.add('active');
                             }
                         });
                     }
                 });
-            }, { rootMargin: "-50% 0px -50% 0px" });
-
-            sections.forEach(section => {
-                observer.observe(section);
-            });
+            }, { rootMargin: '-40% 0px -60% 0px' });
+            sections.forEach(section => observer.observe(section));
         });
     </script>
 </body>

--- a/day_3.html
+++ b/day_3.html
@@ -5,131 +5,152 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Day 3: Inheritance & Polymorphism - OOP Foundations</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Roboto+Mono&display=swap" rel="stylesheet">
-    <!-- Chosen Palette: "Serene Sienna" - a mix of warm neutrals (alabaster, sienna) with a calm blue accent. -->
-    <!-- Application Structure Plan: A two-column layout is chosen for optimal learning experience. The left column features a sticky Table of Contents for seamless navigation through the extensive content. The right column presents the main lesson, logically segmented into Theory, Practice, Design, and Assessment. This structure allows users to easily jump between concepts, review exercises, and test their knowledge without losing context, promoting a non-linear, self-paced learning flow superior to a simple top-to-bottom page. -->
-    <!-- Visualization & Content Choices: 
-        1. Report Info: Abstract Class vs. Interface comparison. -> Goal: Compare/Contrast. -> Viz: Interactive Radar Chart (Chart.js) + detailed HTML table. -> Interaction: Buttons to filter chart data, focusing on unique/shared features. -> Justification: The interactive chart provides a memorable visual "fingerprint" for each concept, while the table offers detailed reference. This dual-approach caters to different learning styles.
-        2. Report Info: UML Diagram. -> Goal: Organize/Visualize hierarchy. -> Viz: HTML/Tailwind-styled divs to mimic a UML diagram. -> Interaction: None (static visual). -> Justification: This method avoids SVG/image dependencies, adhering to constraints while delivering a clear, standard representation of the class structure.
-        3. Report Info: Coding Problems & Solutions. -> Goal: Apply knowledge. -> Viz: Collapsible sections for solutions using HTML/JS. -> Interaction: User clicks to reveal solution. -> Justification: Encourages active problem-solving by hiding the answer, a key pedagogical technique.
-        4. Report Info: Quiz. -> Goal: Test comprehension. -> Viz: Interactive quiz form. -> Interaction: User selects answers and gets immediate JS-driven feedback. -> Justification: Instant feedback reinforces learning concepts immediately and effectively. -->
-    <!-- CONFIRMATION: NO SVG graphics used. NO Mermaid JS used. -->
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Roboto+Mono:wght@400;500&display=swap" rel="stylesheet">
     <style>
         body {
             font-family: 'Inter', sans-serif;
-            background-color: #F8F5F2; /* Alabaster */
-            color: #3D352E; /* Umber */
+            background-color: #FFFFFF;
+            color: #3D352E;
         }
-        .font-mono {
+        h1, h2, h3, h4, h5, h6 {
+            font-family: 'Inter', sans-serif;
+            font-weight: 700;
+        }
+        pre {
+            background-color: #1E1E1E;
+            color: #D4D4D4;
             font-family: 'Roboto Mono', monospace;
+            border-radius: 0.5rem;
+            padding: 1.25rem;
+            position: relative;
+            overflow-x: auto;
+            border: 1px solid #3a404a;
+        }
+        pre code {
+            background-color: transparent !important;
+            color: inherit;
+            padding: 0;
+            font-size: inherit;
+            border-radius: 0;
+        }
+        .prose-custom :not(pre) > code {
+            background-color: #F3F4F6;
+            color: #C06A47;
+            padding: 0.2em 0.4em;
+            border-radius: 3px;
+            font-family: 'Roboto Mono', monospace;
+            font-size: 0.9em;
+        }
+        .btn {
+            display: inline-block;
+            font-weight: 600;
+            padding: 0.5rem 1rem;
+            border-radius: 0.375rem;
+            transition: all 0.2s ease-in-out;
+            cursor: pointer;
+            text-align: center;
+        }
+        .btn-primary {
+            background-color: #C06A47; /* Sienna */
+            color: #FFFFFF;
+            border: 1px solid transparent;
+        }
+        .btn-primary:hover {
+            background-color: #A95A3A; /* Darker Sienna */
+        }
+        .copy-btn {
+            position: absolute;
+            top: 0.75rem;
+            right: 0.75rem;
+            background-color: #4A5568;
+            color: white;
+            border: none;
+            padding: 0.25rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            opacity: 0;
+            transition: all 0.2s;
+        }
+        pre:hover .copy-btn {
+            opacity: 1;
+        }
+        .copy-btn:hover {
+            background-color: #2D3748;
         }
         .toc-link {
             transition: all 0.2s ease-in-out;
             border-left: 2px solid transparent;
         }
-        .toc-link:hover, .toc-link.active {
-            color: #8D5B4C; /* Sienna */
-            border-left-color: #8D5B4C;
-            transform: translateX(4px);
+        .toc-link:hover {
+            color: #3E8A86; /* Teal */
+            border-left-color: #3E8A86;
         }
-        .code-block {
-            background-color: #2D2D2D;
-            color: #EAEAEA;
-            border-radius: 0.5rem;
-            padding: 1rem;
-            position: relative;
+        .toc-link.active {
+            color: #C06A47; /* Sienna */
+            border-left-color: #C06A47;
+            font-weight: 700;
         }
-        .copy-btn {
-            position: absolute;
-            top: 0.5rem;
-            right: 0.5rem;
-            background-color: #4A4A4A;
-            color: white;
-            border: none;
-            padding: 0.25rem 0.5rem;
-            border-radius: 0.25rem;
-            cursor: pointer;
-            font-size: 0.75rem;
-            transition: background-color 0.2s;
-        }
-        .copy-btn:hover {
-            background-color: #6A6A6A;
-        }
-        .section-card {
-            background-color: #FFFFFF;
-            border: 1px solid #E5E0DA; /* Light Beige */
-            border-radius: 0.75rem;
-            box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05), 0 2px 4px -2px rgba(0,0,0,0.05);
-            margin-bottom: 2rem;
-            padding: 2rem;
-        }
-        .callout {
-            background-color: #E9F1F7; /* Pale Blue */
-            border-left: 4px solid #6B9AC4; /* Steel Blue */
-            padding: 1rem;
-            border-radius: 0.5rem;
-            margin: 1.5rem 0;
-        }
-        .syntax-snippet {
-            background-color: #F8F5F2;
-            border: 1px solid #E5E0DA;
-            padding: 1rem;
-            border-radius: 0.5rem;
-            margin: 1rem 0;
-        }
-        .quiz-option {
-            transition: all 0.2s;
-        }
-        .quiz-option.correct {
-            background-color: #D1FAE5;
-            border-color: #10B981;
-        }
-        .quiz-option.incorrect {
-            background-color: #FEE2E2;
-            border-color: #EF4444;
-        }
-        .solution-toggle {
-            cursor: pointer;
-            display: inline-block;
-            padding: 0.5rem 1rem;
-            background-color: #6B9AC4;
-            color: white;
-            border-radius: 0.375rem;
-            transition: background-color 0.2s;
-        }
-        .solution-toggle:hover {
-            background-color: #5A83A9;
-        }
-        .solution-content {
-            display: none;
-            margin-top: 1rem;
-            border-left: 2px solid #E5E0DA;
-            padding-left: 1rem;
-        }
+        .prose-custom { max-width: 80ch; }
+        .prose-custom h2 { margin-top: 2.5em; margin-bottom: 1em; }
+        .prose-custom h3 { margin-top: 2em; margin-bottom: 0.8em; }
+        .prose-custom p, .prose-custom ul, .prose-custom ol { line-height: 1.7; }
+        .shadow-sm { box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05); }
+        .bg-white { background-color: #FFFFFF; }
+        .border, .border-t { border-color: #e5e7eb; }
     </style>
 </head>
-<body class="w-full">
-    <header class="text-center mb-10">
-        <h2 id="greeting" class="text-xl text-slate-500">Good Evening!</h2>
-        <h1 class="text-4xl sm:text-5xl font-extrabold text-slate-800 mt-1 tracking-tight">Low-Level Design Bootcamp</h1>
-        <p class="mt-3 text-slate-500 max-w-xl mx-auto">Your 60-Day Interactive Roadmap to Mastering Backend Engineering.</p>
+<body class="antialiased">
+
+    <!-- Header -->
+    <header class="bg-white shadow-md fixed top-0 left-0 right-0 z-50">
+        <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex justify-between items-center py-3">
+                <div class="text-2xl font-bold text-sienna-800">
+                    <a href="roadmap.html">OOP Foundations</a>
+                </div>
+                <nav class="hidden md:flex space-x-4">
+                    <a href="day_1.html" class="text-gray-600 hover:text-teal-600 transition">Day 1</a>
+                    <a href="day_2.html" class="text-gray-600 hover:text-teal-600 transition">Day 2</a>
+                    <a href="day_3.html" class="font-bold text-teal-600">Day 3</a>
+                    <a href="day_4.html" class="text-gray-600 hover:text-teal-600 transition">Day 4</a>
+                    <a href="day_5.html" class="text-gray-600 hover:text-teal-600 transition">Day 5</a>
+                    <a href="day_6.html" class="text-gray-600 hover:text-teal-600 transition">Day 6</a>
+                    <a href="day_7.html" class="text-gray-600 hover:text-teal-600 transition">Day 7</a>
+                </nav>
+                <!-- Return to Homepage button removed from here -->
+            </div>
+        </div>
     </header>
 
-    <div class="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div class="flex flex-col lg:flex-row lg:space-x-8 py-8">
-            
-            <!-- Right Column: Main Content -->
-            <main class="w-full lg:w-3/4">
-                <a href="lld_homepage.html" class="text-teal-600 hover:text-teal-800 font-semibold transition-colors duration-200 inline-flex items-center">
-                    <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path></svg>
-                    Return to Homepage
-                </a>
-                
-                <!-- Introduction -->
-                <section id="introduction" class="section-card">
+    <main class="container mx-auto px-4 sm:px-6 lg:px-8 pt-24">
+        <div class="flex justify-between items-center mb-12">
+            <div class="text-center">
+                <h1 class="text-4xl md:text-5xl font-bold tracking-tight text-sienna-800">Day 3: Inheritance & Polymorphism</h1>
+                <p class="mt-4 text-xl text-gray-600">Building on yesterday's foundations, today we explore two cornerstone principles of OOP that enable code reuse and flexibility: Inheritance and Polymorphism.</p>
+            </div>
+            <a href="roadmap.html" class="btn btn-primary whitespace-nowrap">Return to Homepage</a>
+        </div>
+
+        <div class="flex flex-col lg:flex-row-reverse lg:space-x-reverse lg:space-x-12">
+            <aside class="w-full lg:w-1/4 lg:sticky lg:top-24 self-start mb-12 lg:mb-0">
+                <div class="p-4 rounded-lg bg-white shadow-sm border">
+                    <h3 class="text-lg font-semibold mb-4">On This Page</h3>
+                    <nav id="toc-nav" class="flex flex-col space-y-2">
+                        <a href="#introduction" class="toc-link pl-2 text-gray-600">Introduction</a>
+                        <a href="#theory" class="toc-link pl-2 text-gray-600">✅ Theory Topics</a>
+                        <a href="#practice" class="toc-link pl-2 text-gray-600">💻 Coding Practice</a>
+                        <a href="#uml" class="toc-link pl-2 text-gray-600">🎨 UML/Schema Task</a>
+                        <a href="#case-study" class="toc-link pl-2 text-gray-600">🚗 Case Study: Ride-Hailing</a>
+                        <a href="#quiz" class="toc-link pl-2 text-gray-600">🧠 Knowledge Check</a>
+                        <a href="#challenge" class="toc-link pl-2 text-gray-600">🚀 Self-Assessment Challenge</a>
+                    </nav>
+                </div>
+            </aside>
+
+            <div class="w-full lg:w-3/4 prose-custom">
+                 <section id="introduction" class="section-card">
                     <h1 class="text-4xl font-bold text-[#8D5B4C] mb-2">Day 3: Inheritance & Polymorphism</h1>
                     <p class="text-lg text-gray-600">Building on yesterday's foundations, today we explore two cornerstone principles of OOP that enable code reuse and flexibility: Inheritance and Polymorphism.</p>
                     <div class="callout">
@@ -198,14 +219,6 @@ myCar.Move(); // Inherited from Vehicle
 
                         <h4 class="font-semibold text-gray-700 my-4">Interactive Comparison</h4>
                         <p class="text-sm text-gray-600 mb-2">Click the buttons to see how features are distributed between Abstract Classes and Interfaces.</p>
-                        <div class="flex space-x-2 mb-4">
-                            <button id="showAllBtn" class="px-3 py-1 bg-blue-500 text-white text-sm rounded-full">Show All</button>
-                            <button id="showAbstractBtn" class="px-3 py-1 bg-gray-200 text-sm rounded-full">Abstract Class</button>
-                            <button id="showInterfaceBtn" class="px-3 py-1 bg-gray-200 text-sm rounded-full">Interface</button>
-                        </div>
-                        <div class="chart-container relative h-96 w-full max-w-lg mx-auto">
-                            <canvas id="comparisonChart"></canvas>
-                        </div>
                         
                         <div class="overflow-x-auto mt-6">
                             <table class="w-full text-left border-collapse">
@@ -1021,199 +1034,49 @@ public class Program
                             </div>
                     </div>
                 </section>
-            </main>
-            <!-- Left Column: Sticky Table of Contents -->
-            <aside class="w-full lg:w-1/4 lg:sticky top-8 self-start mb-8 lg:mb-0">
-                <div class="p-4 bg-white rounded-lg shadow-sm border border-gray-200">
-                    <h3 class="text-lg font-semibold text-[#8D5B4C] mb-4">Lesson Contents</h3>
-                    <nav id="toc-nav">
-                        <ul class="space-y-2">
-                            <li><a href="#introduction" class="toc-link block text-gray-600 hover:text-[#8D5B4C] pl-2">Introduction</a></li>
-                            <li>
-                                <a href="#theory" class="toc-link block font-medium text-gray-800 pl-2">✅ Theory Topics</a>
-                                <ul class="pl-4 mt-2 space-y-2 text-sm">
-                                    <li><a href="#theory-inheritance" class="toc-link block text-gray-600 pl-2">Base & Derived Classes</a></li>
-                                    <li><a href="#theory-abstract-vs-interface" class="toc-link block text-gray-600 pl-2">Abstract Class vs. Interface</a></li>
-                                    <li><a href="#theory-overriding" class="toc-link block text-gray-600 pl-2">Method Overriding</a></li>
-                                    <li><a href="#theory-polymorphism" class="toc-link block text-gray-600 pl-2">Polymorphism in Practice</a></li>
-                                </ul>
-                            </li>
-                            <li>
-                                <a href="#practice" class="toc-link block font-medium text-gray-800 pl-2">💻 Coding Practice</a>
-                                <ul class="pl-4 mt-2 space-y-2 text-sm">
-                                    <li><a href="#practice-shape" class="toc-link block text-gray-600 pl-2">Base: Shape Hierarchy</a></li>
-                                    <li><a href="#practice-animal" class="toc-link block text-gray-600 pl-2">Easy: Animal Hierarchy</a></li>
-                                    <li><a href="#practice-payment" class="toc-link block text-gray-600 pl-2">Medium: Payment Processor</a></li>
-                                    <li><a href="#practice-notification" class="toc-link block text-gray-600 pl-2">Hard: Notification System</a></li>
-                                </ul>
-                            </li>
-                            <li><a href="#uml" class="toc-link block font-medium text-gray-800 pl-2">🎨 UML/Schema Task</a></li>
-                            <li><a href="#case-study" class="toc-link block font-medium text-gray-800 pl-2">🚗 Case Study: Ride-Hailing</a></li>
-                            <li><a href="#quiz" class="toc-link block font-medium text-gray-800 pl-2">🧠 Knowledge Check</a></li>
-                            <li><a href="#challenge" class="toc-link block font-medium text-gray-800 pl-2">🚀 Self-Assessment Challenge</a></li>
-                        </ul>
-                    </nav>
-                </div>
-            </aside>
+            </div>
         </div>
-    </div>
-    
-    <footer class="text-center mt-16 py-8 border-t border-slate-200">
-        <p class="text-slate-700 font-semibold">Low-Level Design Bootcamp</p>
-        <p class="text-sm text-slate-500 mt-2">A personalized learning roadmap curated by Mr. Mahesh Singare.</p>
-        <p class="text-xs text-slate-400 mt-4">&copy; 2025. All Rights Reserved.</p>
+    </main>
+
+    <footer class="mt-16 py-8 bg-white border-t">
+        <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
+            <div class="flex justify-center mb-4">
+                <a href="roadmap.html" class="btn btn-primary">Return to Homepage</a>
+            </div>
+            <p class="text-gray-500">&copy; 2025 OOP Foundations. All Rights Reserved.</p>
+            <p class="text-sm mt-1 text-gray-500">A self-contained learning module.</p>
+        </div>
     </footer>
 
     <script>
-        document.addEventListener('DOMContentLoaded', () => {
-            // Copy-to-clipboard functionality
-            document.querySelectorAll('.copy-btn').forEach(button => {
-                button.addEventListener('click', () => {
-                    const code = button.nextElementSibling.querySelector('code').innerText;
+        document.addEventListener('DOMContentLoaded', function () {
+            // --- Copy-to-Clipboard ---
+            document.querySelectorAll('.copy-btn').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    const code = btn.parentElement.querySelector('pre code').innerText;
                     navigator.clipboard.writeText(code).then(() => {
-                        button.innerText = 'Copied!';
-                        setTimeout(() => {
-                            button.innerText = 'Copy';
-                        }, 2000);
-                    }).catch(err => {
-                        console.error('Failed to copy text: ', err);
+                        btn.textContent = 'Copied!';
+                        setTimeout(() => btn.textContent = 'Copy', 2000);
                     });
                 });
             });
 
-            // Solution toggling
-            window.toggleSolution = (id) => {
-                const content = document.getElementById(id);
-                if (content.style.display === 'block') {
-                    content.style.display = 'none';
-                } else {
-                    content.style.display = 'block';
-                }
-            };
-            
-            // Quiz functionality
-            document.querySelectorAll('.quiz-question').forEach(question => {
-                const options = question.querySelectorAll('input[type="radio"]');
-                const correctAnswerIndex = parseInt(question.dataset.correct, 10);
-                const feedbackEl = question.querySelector('.quiz-feedback');
-                
-                options.forEach((option, index) => {
-                    option.addEventListener('change', () => {
-                        // Reset styles
-                        options.forEach(opt => opt.parentElement.classList.remove('correct', 'incorrect'));
-                        
-                        if(index === correctAnswerIndex) {
-                            option.parentElement.classList.add('correct');
-                            feedbackEl.textContent = 'Correct! Great job.';
-                            feedbackEl.className = 'quiz-feedback text-sm mt-2 text-green-600 block';
-                        } else {
-                            option.parentElement.classList.add('incorrect');
-                            options[correctAnswerIndex].parentElement.classList.add('correct');
-                            feedbackEl.textContent = 'Not quite. The correct answer is highlighted in green.';
-                            feedbackEl.className = 'quiz-feedback text-sm mt-2 text-red-600 block';
-                        }
-                    });
-                });
-            });
-
-            // TOC Active State Scrolling
+            // --- Active TOC Link ---
+            const sections = document.querySelectorAll('main section');
             const tocLinks = document.querySelectorAll('.toc-link');
-            const sections = document.querySelectorAll('section, div[id^="theory-"]');
-            
-            const observer = new IntersectionObserver((entries) => {
+            const observer = new IntersectionObserver(entries => {
                 entries.forEach(entry => {
                     if (entry.isIntersecting) {
-                        const id = entry.target.getAttribute('id');
                         tocLinks.forEach(link => {
                             link.classList.remove('active');
-                            if (link.getAttribute('href') === `#${id}`) {
+                            if (link.getAttribute('href') === `#${entry.target.id}`) {
                                 link.classList.add('active');
                             }
                         });
                     }
                 });
-            }, { rootMargin: '-20% 0px -80% 0px', threshold: 0 });
-
-            sections.forEach(section => {
-                observer.observe(section);
-            });
-            
-            // Chart.js Visualization
-            const ctx = document.getElementById('comparisonChart').getContext('2d');
-            
-            const fullData = {
-                labels: ['Fields', 'Constructors', 'Method Implementation', 'Access Modifiers', 'Multiple Inheritance', 'Abstract Members'],
-                datasets: [{
-                    label: 'Abstract Class',
-                    data: [1, 1, 1, 1, 0, 1],
-                    backgroundColor: 'rgba(107, 154, 196, 0.2)',
-                    borderColor: 'rgba(107, 154, 196, 1)',
-                    borderWidth: 2,
-                    pointBackgroundColor: 'rgba(107, 154, 196, 1)'
-                }, {
-                    label: 'Interface',
-                    data: [0, 0, 0, 0, 1, 1],
-                    backgroundColor: 'rgba(141, 91, 76, 0.2)',
-                    borderColor: 'rgba(141, 91, 76, 1)',
-                    borderWidth: 2,
-                    pointBackgroundColor: 'rgba(141, 91, 76, 1)'
-                }]
-            };
-
-            let comparisonChart = new Chart(ctx, {
-                type: 'radar',
-                data: JSON.parse(JSON.stringify(fullData)),
-                options: {
-                    maintainAspectRatio: false,
-                    scales: {
-                        r: {
-                            angleLines: {
-                                color: '#E5E0DA'
-                            },
-                            grid: {
-                                color: '#E5E0DA'
-                            },
-                            pointLabels: {
-                                font: {
-                                    size: 12
-                                },
-                                color: '#3D352E'
-                            },
-                            ticks: {
-                                backdropColor: '#F8F5F2',
-                                color: '#8D5B4C',
-                                stepSize: 1,
-                                display: false
-                            },
-                            beginAtZero: true,
-                            max: 1
-                        }
-                    },
-                    plugins: {
-                        legend: {
-                            position: 'top',
-                        },
-                        tooltip: {
-                             callbacks: {
-                                label: function(context) {
-                                    return context.dataset.label + ': ' + (context.raw === 1 ? 'Yes' : 'No');
-                                }
-                            }
-                        }
-                    }
-                }
-            });
-
-            const updateChartData = (datasetsToShow) => {
-                 const newData = JSON.parse(JSON.stringify(fullData));
-                 newData.datasets = fullData.datasets.filter(ds => datasetsToShow.includes(ds.label));
-                 comparisonChart.data = newData;
-                 comparisonChart.update();
-            }
-
-            document.getElementById('showAllBtn').addEventListener('click', () => updateChartData(['Abstract Class', 'Interface']));
-            document.getElementById('showAbstractBtn').addEventListener('click', () => updateChartData(['Abstract Class']));
-            document.getElementById('showInterfaceBtn').addEventListener('click', () => updateChartData(['Interface']));
+            }, { rootMargin: '-40% 0px -60% 0px' });
+            sections.forEach(section => observer.observe(section));
         });
     </script>
 </body>

--- a/day_4.html
+++ b/day_4.html
@@ -3,57 +3,154 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>OOP Day 4: Immutability & Value Types</title>
+    <title>Day 4: Immutability & Value Types - OOP Foundations</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <!-- Chosen Palette: Calm Harmony -->
-    <!-- Application Structure Plan: A two-column layout is chosen for optimal learning. A sticky navigation sidebar on the left provides an 'always-on' table of contents for easy jumping between complex topics, preventing disorientation. The main content area on the right follows a logical, sequential flow from theory to practical application. This structure supports both linear learning for beginners and quick reference for returning users. Interactive elements like a memory visualizer and a quiz are embedded directly within the flow to reinforce concepts immediately after they are introduced, which is a pedagogically sound approach to solidifying technical knowledge. -->
-    <!-- Visualization & Content Choices: Report Info: Value vs. Reference types. Goal: Clarify abstract memory allocation. Viz/Method: Interactive HTML/CSS/JS diagram showing Stack and Heap. Interaction: User clicks buttons to create types, triggering animations that visualize memory pointers vs. direct data storage. Justification: This makes a difficult concept tangible and memorable. Report Info: UML for Order states. Goal: Show state transitions. Viz/Method: Diagram built with styled HTML divs. Interaction: Hovering over states or transitions reveals tooltips with explanations. Justification: Avoids static images or external tools, keeping the module self-contained and interactive. All code examples use custom-styled blocks with a copy-to-clipboard feature for practicality. The quiz uses immediate feedback to enhance learning. -->
-    <!-- CONFIRMATION: NO SVG graphics used. NO Mermaid JS used. -->
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Roboto+Mono:wght@400;500&display=swap" rel="stylesheet">
     <style>
-        body { font-family: 'Inter', sans-serif; background-color: #f8fafc; }
-        .toc-link.active { color: #0891b2; font-weight: 600; border-left-color: #0891b2; }
-        .code-block { background-color: #1e293b; color: #e2e8f0; border-radius: 0.5rem; overflow: hidden; margin-top: 1rem; margin-bottom: 1rem; }
-        .code-header { background-color: #334155; padding: 0.5rem 1rem; display: flex; justify-content: space-between; align-items: center; }
-        .code-header span { font-size: 0.875rem; color: #cbd5e1; }
-        .copy-btn { background-color: #475569; color: #e2e8f0; border: none; padding: 0.25rem 0.75rem; border-radius: 0.25rem; cursor: pointer; font-size: 0.875rem; }
-        .copy-btn:hover { background-color: #64748b; }
-        .code-content { padding: 1rem; white-space: pre-wrap; word-wrap: break-word; font-family: monospace; font-size: 0.9rem; line-height: 1.5; }
-        .code-content .keyword { color: #93c5fd; } .code-content .type { color: #6ee7b7; } .code-content .comment { color: #6b7280; } .code-content .string { color: #fde047; } .code-content .number { color: #f0abfc; }
-        .tab.active { border-color: #0891b2; background-color: #fff; color: #0891b2; }
-        .tab-content { display: none; } .tab-content.active { display: block; }
-        .quiz-option.correct { background-color: #dcfce7; border-color: #22c55e; } .quiz-option.incorrect { background-color: #fee2e2; border-color: #ef4444; }
-        .accordion-content { max-height: 0; overflow: hidden; transition: max-height 0.3s ease-out; }
-        .memory-box { border: 2px solid #94a3b8; border-radius: 0.375rem; padding: 0.5rem; text-align: center; transition: all 0.3s ease; }
-        .memory-arrow { position: absolute; height: 2px; background: #0891b2; transform-origin: left center; transition: all 0.5s ease-in-out; }
+        body {
+            font-family: 'Inter', sans-serif;
+            background-color: #FFFFFF;
+            color: #3D352E;
+        }
+        h1, h2, h3, h4, h5, h6 {
+            font-family: 'Inter', sans-serif;
+            font-weight: 700;
+        }
+        pre {
+            background-color: #1E1E1E;
+            color: #D4D4D4;
+            font-family: 'Roboto Mono', monospace;
+            border-radius: 0.5rem;
+            padding: 1.25rem;
+            position: relative;
+            overflow-x: auto;
+            border: 1px solid #3a404a;
+        }
+        pre code {
+            background-color: transparent !important;
+            color: inherit;
+            padding: 0;
+            font-size: inherit;
+            border-radius: 0;
+        }
+        .prose-custom :not(pre) > code {
+            background-color: #F3F4F6;
+            color: #C06A47;
+            padding: 0.2em 0.4em;
+            border-radius: 3px;
+            font-family: 'Roboto Mono', monospace;
+            font-size: 0.9em;
+        }
+        .btn {
+            display: inline-block;
+            font-weight: 600;
+            padding: 0.5rem 1rem;
+            border-radius: 0.375rem;
+            transition: all 0.2s ease-in-out;
+            cursor: pointer;
+            text-align: center;
+        }
+        .btn-primary {
+            background-color: #C06A47; /* Sienna */
+            color: #FFFFFF;
+            border: 1px solid transparent;
+        }
+        .btn-primary:hover {
+            background-color: #A95A3A; /* Darker Sienna */
+        }
+        .copy-btn {
+            position: absolute;
+            top: 0.75rem;
+            right: 0.75rem;
+            background-color: #4A5568;
+            color: white;
+            border: none;
+            padding: 0.25rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            opacity: 0;
+            transition: all 0.2s;
+        }
+        pre:hover .copy-btn {
+            opacity: 1;
+        }
+        .copy-btn:hover {
+            background-color: #2D3748;
+        }
+        .toc-link {
+            transition: all 0.2s ease-in-out;
+            border-left: 2px solid transparent;
+        }
+        .toc-link:hover {
+            color: #3E8A86; /* Teal */
+            border-left-color: #3E8A86;
+        }
+        .toc-link.active {
+            color: #C06A47; /* Sienna */
+            border-left-color: #C06A47;
+            font-weight: 700;
+        }
+        .prose-custom { max-width: 80ch; }
+        .prose-custom h2 { margin-top: 2.5em; margin-bottom: 1em; }
+        .prose-custom h3 { margin-top: 2em; margin-bottom: 0.8em; }
+        .prose-custom p, .prose-custom ul, .prose-custom ol { line-height: 1.7; }
+        .shadow-sm { box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05); }
+        .bg-white { background-color: #FFFFFF; }
+        .border, .border-t { border-color: #e5e7eb; }
     </style>
 </head>
-<body class="text-slate-700">
+<body class="antialiased">
 
-    <header class="text-center mb-10">
-        <h2 id="greeting" class="text-xl text-slate-500">Good Evening!</h2>
-        <h1 class="text-4xl sm:text-5xl font-extrabold text-slate-800 mt-1 tracking-tight">Low-Level Design Bootcamp</h1>
-        <p class="mt-3 text-slate-500 max-w-xl mx-auto">Your 60-Day Interactive Roadmap to Mastering Backend Engineering.</p>
+    <!-- Header -->
+    <header class="bg-white shadow-md fixed top-0 left-0 right-0 z-50">
+        <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex justify-between items-center py-3">
+                <div class="text-2xl font-bold text-sienna-800">
+                    <a href="roadmap.html">OOP Foundations</a>
+                </div>
+                <nav class="hidden md:flex space-x-4">
+                    <a href="day_1.html" class="text-gray-600 hover:text-teal-600 transition">Day 1</a>
+                    <a href="day_2.html" class="text-gray-600 hover:text-teal-600 transition">Day 2</a>
+                    <a href="day_3.html" class="text-gray-600 hover:text-teal-600 transition">Day 3</a>
+                    <a href="day_4.html" class="font-bold text-teal-600">Day 4</a>
+                    <a href="day_5.html" class="text-gray-600 hover:text-teal-600 transition">Day 5</a>
+                    <a href="day_6.html" class="text-gray-600 hover:text-teal-600 transition">Day 6</a>
+                    <a href="day_7.html" class="text-gray-600 hover:text-teal-600 transition">Day 7</a>
+                </nav>
+                <!-- Return to Homepage button removed from here -->
+            </div>
+        </div>
     </header>
 
-    <div class="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div class="lg:flex lg:space-x-8">
-            <!-- Main Content -->
-            <main class="flex-1 min-w-0">
-                <a href="lld_homepage.html" class="text-teal-600 hover:text-teal-800 font-semibold transition-colors duration-200 inline-flex items-center">
-                    <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path></svg>
-                    Return to Homepage
-                </a>
-                <article class="prose lg:prose-xl max-w-none">
-                    <header class="mb-12">
-                        <p class="text-base font-semibold text-cyan-600">OOP Foundations: Day 4</p>
-                        <h1 class="text-4xl md:text-5xl font-bold tracking-tight text-slate-900">Immutability & Value Types</h1>
-                        <p class="mt-4 text-lg text-slate-600">Discover the power of immutable data structures. Learn how to build safer, more predictable, and thread-safe applications by understanding the fundamental difference between data that can change and data that cannot.</p>
-                    </header>
-                    
-                    <!-- Core Theory -->
+    <main class="container mx-auto px-4 sm:px-6 lg:px-8 pt-24">
+        <div class="flex justify-between items-center mb-12">
+            <div class="text-center">
+                <h1 class="text-4xl md:text-5xl font-bold tracking-tight text-sienna-800">Immutability & Value Types</h1>
+                <p class="mt-4 text-xl text-gray-600">Discover the power of immutable data structures. Learn how to build safer, more predictable, and thread-safe applications by understanding the fundamental difference between data that can change and data that cannot.</p>
+            </div>
+            <a href="roadmap.html" class="btn btn-primary whitespace-nowrap">Return to Homepage</a>
+        </div>
+
+        <div class="flex flex-col lg:flex-row-reverse lg:space-x-reverse lg:space-x-12">
+            <aside class="w-full lg:w-1/4 lg:sticky lg:top-24 self-start mb-12 lg:mb-0">
+                <div class="p-4 rounded-lg bg-white shadow-sm border">
+                    <h3 class="text-lg font-semibold mb-4">On This Page</h3>
+                    <nav id="toc-nav" class="flex flex-col space-y-2">
+                        <a href="#theory" class="toc-link pl-2 text-gray-600">Core Theory</a>
+                        <a href="#visualization" class="toc-link pl-2 text-gray-600">Interactive Visualization</a>
+                        <a href="#practice" class="toc-link pl-2 text-gray-600">Coding Practice</a>
+                        <a href="#uml" class="toc-link pl-2 text-gray-600">UML/Schema Task</a>
+                        <a href="#case-study" class="toc-link pl-2 text-gray-600">Case Study</a>
+                        <a href="#quiz" class="toc-link pl-2 text-gray-600">Knowledge Check</a>
+                        <a href="#challenge" class="toc-link pl-2 text-gray-600">Self-Assessment</a>
+                    </nav>
+                </div>
+            </aside>
+
+            <div class="w-full lg:w-3/4 prose-custom">
+                 <!-- Core Theory -->
                     <section id="theory" class="scroll-mt-20 mb-16">
                         <h2 class="text-3xl font-bold text-slate-900 border-b pb-2 mb-6">Core Theory: The Bedrock of Predictability</h2>
                         <p class="mb-6">At the heart of immutability is a simple promise: once a piece of data is created, it can never be changed. This seems restrictive, but it unlocks incredible benefits in complex systems, especially when multiple threads or processes are involved. We'll start by exploring the two fundamental ways C# stores data: as values and as references.</p>
@@ -537,218 +634,50 @@
                             </div>
                         </div>
                     </section>
-
-                </article>
-            </main>
-            <!-- Table of Contents (Sticky) -->
-            <nav id="toc" class="hidden lg:block w-64 shrink-0 sticky top-20 self-start">
-                <div class="space-y-4">
-                    <h3 class="font-semibold text-slate-900 text-lg">On this page</h3>
-                    <ul class="space-y-2 text-slate-500">
-                        <li><a href="#theory" class="toc-link block border-l-2 border-transparent pl-4 hover:text-cyan-600 hover:border-cyan-600 transition-colors duration-200">Core Theory</a></li>
-                        <li><a href="#visualization" class="toc-link block border-l-2 border-transparent pl-4 hover:text-cyan-600 hover:border-cyan-600 transition-colors duration-200">Interactive Visualization</a></li>
-                        <li><a href="#practice" class="toc-link block border-l-2 border-transparent pl-4 hover:text-cyan-600 hover:border-cyan-600 transition-colors duration-200">Coding Practice</a></li>
-                        <li><a href="#uml" class="toc-link block border-l-2 border-transparent pl-4 hover:text-cyan-600 hover:border-cyan-600 transition-colors duration-200">UML/Schema Task</a></li>
-                        <li><a href="#case-study" class="toc-link block border-l-2 border-transparent pl-4 hover:text-cyan-600 hover:border-cyan-600 transition-colors duration-200">Case Study</a></li>
-                        <li><a href="#quiz" class="toc-link block border-l-2 border-transparent pl-4 hover:text-cyan-600 hover:border-cyan-600 transition-colors duration-200">Knowledge Check</a></li>
-                        <li><a href="#challenge" class="toc-link block border-l-2 border-transparent pl-4 hover:text-cyan-600 hover:border-cyan-600 transition-colors duration-200">Self-Assessment</a></li>
-                    </ul>
-                </div>
-            </nav>
+            </div>
         </div>
-    </div>
-    
-    <footer class="text-center mt-16 py-8 border-t border-slate-200">
-        <p class="text-slate-700 font-semibold">Low-Level Design Bootcamp</p>
-        <p class="text-sm text-slate-500 mt-2">A personalized learning roadmap curated by Mr. Mahesh Singare.</p>
-        <p class="text-xs text-slate-400 mt-4">&copy; 2025. All Rights Reserved.</p>
+    </main>
+
+    <footer class="mt-16 py-8 bg-white border-t">
+        <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
+            <div class="flex justify-center mb-4">
+                <a href="roadmap.html" class="btn btn-primary">Return to Homepage</a>
+            </div>
+            <p class="text-gray-500">&copy; 2025 OOP Foundations. All Rights Reserved.</p>
+            <p class="text-sm mt-1 text-gray-500">A self-contained learning module.</p>
+        </div>
     </footer>
 
-<script>
-document.addEventListener('DOMContentLoaded', () => {
-
-    // --- Copy-to-Clipboard Functionality ---
-    document.querySelectorAll('.copy-btn').forEach(button => {
-        button.addEventListener('click', () => {
-            const codeContent = button.closest('.code-block').querySelector('.code-content');
-            const textToCopy = codeContent.innerText;
-            
-            const tempTextArea = document.createElement('textarea');
-            tempTextArea.value = textToCopy;
-            document.body.appendChild(tempTextArea);
-            tempTextArea.select();
-            document.execCommand('copy');
-            document.body.removeChild(tempTextArea);
-
-            button.textContent = 'Copied!';
-            setTimeout(() => {
-                button.textContent = 'Copy';
-            }, 2000);
-        });
-    });
-
-    // --- Tabs Functionality ---
-    const tabs = document.querySelectorAll('.tab');
-    const tabContents = document.querySelectorAll('.tab-content');
-    tabs.forEach(tab => {
-        tab.addEventListener('click', () => {
-            const target = tab.getAttribute('data-tab');
-
-            tabs.forEach(t => t.classList.remove('active'));
-            tab.classList.add('active');
-
-            tabContents.forEach(content => {
-                if (content.id === `tab-${target}`) {
-                    content.classList.add('active');
-                } else {
-                    content.classList.remove('active');
-                }
-            });
-        });
-    });
-
-    // --- Accordion Functionality ---
-    document.querySelectorAll('.accordion-toggle').forEach(button => {
-        button.addEventListener('click', () => {
-            const content = button.nextElementSibling;
-            if (content.style.maxHeight) {
-                content.style.maxHeight = null;
-            } else {
-                content.style.maxHeight = content.scrollHeight + 'px';
-            }
-        });
-    });
-
-    // --- Quiz Functionality ---
-    document.querySelectorAll('.quiz-option').forEach(button => {
-        button.addEventListener('click', () => {
-            const questionDiv = button.closest('.quiz-question');
-            const optionsContainer = button.parentElement;
-            const correctAnswer = optionsContainer.getAttribute('data-answer');
-            const selectedOption = button.getAttribute('data-option');
-            const feedbackDiv = questionDiv.querySelector('.quiz-feedback');
-
-            optionsContainer.querySelectorAll('.quiz-option').forEach(opt => {
-                opt.disabled = true;
-                opt.classList.remove('hover:bg-slate-100');
-            });
-            
-            if (selectedOption === correctAnswer) {
-                button.classList.add('correct');
-                feedbackDiv.textContent = 'Correct! This is the main advantage for concurrent programming.';
-                if(correctAnswer === 'a') feedbackDiv.textContent = 'Correct! Value types are allocated on the fast stack memory.';
-                if(correctAnswer === 'c') feedbackDiv.textContent = 'Correct! Records provide the most modern and concise syntax for immutability.';
-                feedbackDiv.className = 'quiz-feedback mt-2 p-2 text-sm rounded-lg bg-green-100 text-green-800';
-            } else {
-                button.classList.add('incorrect');
-                const correctButton = optionsContainer.querySelector(`[data-option="${correctAnswer}"]`);
-                correctButton.classList.add('correct');
-                feedbackDiv.textContent = 'Not quite. The correct answer is highlighted in green.';
-                feedbackDiv.className = 'quiz-feedback mt-2 p-2 text-sm rounded-lg bg-red-100 text-red-800';
-            }
-        });
-    });
-
-    // --- Table of Contents Active Link Highlighting ---
-    const tocLinks = document.querySelectorAll('.toc-link');
-    const sections = document.querySelectorAll('section');
-
-    const observer = new IntersectionObserver(entries => {
-        entries.forEach(entry => {
-            if (entry.isIntersecting) {
-                const id = entry.target.getAttribute('id');
-                tocLinks.forEach(link => {
-                    link.classList.toggle('active', link.getAttribute('href') === `#${id}`);
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            // --- Copy-to-Clipboard ---
+            document.querySelectorAll('.copy-btn').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    const code = btn.parentElement.querySelector('pre code').innerText;
+                    navigator.clipboard.writeText(code).then(() => {
+                        btn.textContent = 'Copied!';
+                        setTimeout(() => btn.textContent = 'Copy', 2000);
+                    });
                 });
-            }
+            });
+
+            // --- Active TOC Link ---
+            const sections = document.querySelectorAll('main section');
+            const tocLinks = document.querySelectorAll('.toc-link');
+            const observer = new IntersectionObserver(entries => {
+                entries.forEach(entry => {
+                    if (entry.isIntersecting) {
+                        tocLinks.forEach(link => {
+                            link.classList.remove('active');
+                            if (link.getAttribute('href') === `#${entry.target.id}`) {
+                                link.classList.add('active');
+                            }
+                        });
+                    }
+                });
+            }, { rootMargin: '-40% 0px -60% 0px' });
+            sections.forEach(section => observer.observe(section));
         });
-    }, { rootMargin: '-20% 0px -70% 0px' });
-
-    sections.forEach(section => observer.observe(section));
-
-    // --- Interactive Visualization Logic ---
-    const createValueTypeBtn = document.getElementById('createValueTypeBtn');
-    const createRefTypeBtn = document.getElementById('createRefTypeBtn');
-    const resetVizBtn = document.getElementById('resetVizBtn');
-    const stackArea = document.getElementById('stack-area');
-    const heapArea = document.getElementById('heap-area');
-    const arrowContainer = document.getElementById('arrow-container');
-
-    let valueCount = 0;
-    let refCount = 0;
-    
-    const resetViz = () => {
-        valueCount = 0;
-        refCount = 0;
-        stackArea.innerHTML = '';
-        heapArea.innerHTML = '';
-        arrowContainer.innerHTML = '';
-    };
-    
-    const createArrow = (startElem, endElem) => {
-        const arrow = document.createElement('div');
-        arrow.className = 'memory-arrow';
-        arrowContainer.appendChild(arrow);
-    
-        const updateArrow = () => {
-            const startRect = startElem.getBoundingClientRect();
-            const endRect = endElem.getBoundingClientRect();
-            const containerRect = arrowContainer.getBoundingClientRect();
-    
-            const startX = startRect.right - containerRect.left;
-            const startY = startRect.top + startRect.height / 2 - containerRect.top;
-            const endX = endRect.left - containerRect.left;
-            const endY = endRect.top + endRect.height / 2 - containerRect.top;
-            
-            const dx = endX - startX;
-            const dy = endY - startY;
-            const length = Math.sqrt(dx * dx + dy * dy);
-            const angle = Math.atan2(dy, dx) * 180 / Math.PI;
-
-            arrow.style.left = `${startX}px`;
-            arrow.style.top = `${startY}px`;
-            arrow.style.width = `${length}px`;
-            arrow.style.transform = `rotate(${angle}deg)`;
-        };
-
-        // Call once to position and then again if window resizes
-        updateArrow();
-        window.addEventListener('resize', updateArrow);
-    };
-
-    createValueTypeBtn.addEventListener('click', () => {
-        valueCount++;
-        const id = `point${valueCount}`;
-        const stackItem = document.createElement('div');
-        stackItem.id = `stack-${id}`;
-        stackItem.className = 'memory-box bg-cyan-100 border-cyan-500 w-4/5';
-        stackItem.innerHTML = `<span class="font-mono text-sm font-semibold">${id}</span><div class="text-xs text-cyan-800">Point { X: ${Math.floor(Math.random()*10)}, Y: ${Math.floor(Math.random()*10)} }</div>`;
-        stackArea.appendChild(stackItem);
-    });
-
-    createRefTypeBtn.addEventListener('click', () => {
-        refCount++;
-        const id = `user${refCount}`;
-        const address = `0x${Math.floor(Math.random() * 0xFFF).toString(16).toUpperCase()}`;
-
-        const stackItem = document.createElement('div');
-        stackItem.id = `stack-${id}`;
-        stackItem.className = 'memory-box bg-teal-100 border-teal-500 w-4/5';
-        stackItem.innerHTML = `<span class="font-mono text-sm font-semibold">${id}</span><div class="text-xs text-teal-800">ref: ${address}</div>`;
-        stackArea.appendChild(stackItem);
-        
-        const heapItem = document.createElement('div');
-        heapItem.id = `heap-${id}`;
-        heapItem.className = 'memory-box bg-emerald-100 border-emerald-500 w-4/5';
-        heapItem.innerHTML = `<span class="font-mono text-xs">${address}</span><div class="text-sm font-semibold">User Object</div><div class="text-xs text-emerald-800">{ Name: "...", Email: "..." }</div>`;
-        heapArea.appendChild(heapItem);
-        
-        // Timeout to allow elements to render before drawing arrow
-        setTimeout(() => createArrow(stackItem, heapItem), 100);
-    });
-
-    resetVizBtn.addEventListener('click', resetViz);
-});
-</script>
+    </script>
 </body>
 </html>

--- a/day_5.html
+++ b/day_5.html
@@ -3,94 +3,154 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>OOP Day 5: Overloading, Overriding & Extension Methods</title>
+    <title>Day 5: Method Overloading, Overriding & Extension Methods - OOP Foundations</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Roboto+Mono:wght@400;500&display=swap" rel="stylesheet">
     <style>
         body {
             font-family: 'Inter', sans-serif;
+            background-color: #FFFFFF;
+            color: #3D352E;
         }
-        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Roboto+Mono:wght@400;500&display=swap');
-        
-        pre[class*="language-"] {
-            position: relative;
-            overflow: auto;
-            border-radius: 0.5rem;
-            box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-            padding: 1.25rem;
-            padding-top: 3rem; /* Make space for buttons */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: 'Inter', sans-serif;
+            font-weight: 700;
         }
-        
-        code[class*="language-"] {
+        pre {
+            background-color: #1E1E1E;
+            color: #D4D4D4;
             font-family: 'Roboto Mono', monospace;
-            font-size: 0.875rem;
+            border-radius: 0.5rem;
+            padding: 1.25rem;
+            position: relative;
+            overflow-x: auto;
+            border: 1px solid #3a404a;
         }
-
-        .code-actions {
+        pre code {
+            background-color: transparent !important;
+            color: inherit;
+            padding: 0;
+            font-size: inherit;
+            border-radius: 0;
+        }
+        .prose-custom :not(pre) > code {
+            background-color: #F3F4F6;
+            color: #C06A47;
+            padding: 0.2em 0.4em;
+            border-radius: 3px;
+            font-family: 'Roboto Mono', monospace;
+            font-size: 0.9em;
+        }
+        .btn {
+            display: inline-block;
+            font-weight: 600;
+            padding: 0.5rem 1rem;
+            border-radius: 0.375rem;
+            transition: all 0.2s ease-in-out;
+            cursor: pointer;
+            text-align: center;
+        }
+        .btn-primary {
+            background-color: #C06A47; /* Sienna */
+            color: #FFFFFF;
+            border: 1px solid transparent;
+        }
+        .btn-primary:hover {
+            background-color: #A95A3A; /* Darker Sienna */
+        }
+        .copy-btn {
             position: absolute;
             top: 0.75rem;
             right: 0.75rem;
-            display: flex;
-            gap: 0.5rem;
-        }
-        
-        .code-btn {
-            background-color: #4a5568;
+            background-color: #4A5568;
             color: white;
             border: none;
-            padding: 0.25rem 0.6rem;
-            border-radius: 0.375rem;
+            padding: 0.25rem 0.5rem;
+            border-radius: 0.25rem;
             font-size: 0.75rem;
-            cursor: pointer;
-            opacity: 0.7;
-            transition: all 0.2s ease;
+            opacity: 0;
+            transition: all 0.2s;
         }
-
-        pre:hover .code-btn {
+        pre:hover .copy-btn {
             opacity: 1;
         }
-
-        .code-btn:hover {
-            background-color: #2d3748;
+        .copy-btn:hover {
+            background-color: #2D3748;
         }
-        
+        .toc-link {
+            transition: all 0.2s ease-in-out;
+            border-left: 2px solid transparent;
+        }
+        .toc-link:hover {
+            color: #3E8A86; /* Teal */
+            border-left-color: #3E8A86;
+        }
         .toc-link.active {
-            color: #4f46e5;
-            font-weight: 600;
-            border-left-color: #4f46e5;
+            color: #C06A47; /* Sienna */
+            border-left-color: #C06A47;
+            font-weight: 700;
         }
-        .spinner {
-            border: 4px solid rgba(0, 0, 0, 0.1);
-            width: 36px;
-            height: 36px;
-            border-radius: 50%;
-            border-left-color: #4f46e5;
-            animation: spin 1s ease infinite;
-        }
-        @keyframes spin {
-            0% { transform: rotate(0deg); }
-            100% { transform: rotate(360deg); }
-        }
+        .prose-custom { max-width: 80ch; }
+        .prose-custom h2 { margin-top: 2.5em; margin-bottom: 1em; }
+        .prose-custom h3 { margin-top: 2em; margin-bottom: 0.8em; }
+        .prose-custom p, .prose-custom ul, .prose-custom ol { line-height: 1.7; }
+        .shadow-sm { box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05); }
+        .bg-white { background-color: #FFFFFF; }
+        .border, .border-t { border-color: #e5e7eb; }
     </style>
 </head>
-<body class="bg-gray-50 text-gray-800">
-    <header class="text-center mb-10">
-        <h2 id="greeting" class="text-xl text-slate-500">Good Evening!</h2>
-        <h1 class="text-4xl sm:text-5xl font-extrabold text-slate-800 mt-1 tracking-tight">Low-Level Design Bootcamp</h1>
-        <p class="mt-3 text-slate-500 max-w-xl mx-auto">Your 60-Day Interactive Roadmap to Mastering Backend Engineering.</p>
+<body class="antialiased">
+
+    <!-- Header -->
+    <header class="bg-white shadow-md fixed top-0 left-0 right-0 z-50">
+        <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex justify-between items-center py-3">
+                <div class="text-2xl font-bold text-sienna-800">
+                    <a href="roadmap.html">OOP Foundations</a>
+                </div>
+                <nav class="hidden md:flex space-x-4">
+                    <a href="day_1.html" class="text-gray-600 hover:text-teal-600 transition">Day 1</a>
+                    <a href="day_2.html" class="text-gray-600 hover:text-teal-600 transition">Day 2</a>
+                    <a href="day_3.html" class="text-gray-600 hover:text-teal-600 transition">Day 3</a>
+                    <a href="day_4.html" class="text-gray-600 hover:text-teal-600 transition">Day 4</a>
+                    <a href="day_5.html" class="font-bold text-teal-600">Day 5</a>
+                    <a href="day_6.html" class="text-gray-600 hover:text-teal-600 transition">Day 6</a>
+                    <a href="day_7.html" class="text-gray-600 hover:text-teal-600 transition">Day 7</a>
+                </nav>
+                <!-- Return to Homepage button removed from here -->
+            </div>
+        </div>
     </header>
 
-    <div class="container mx-auto px-4 py-8">
-        <div class="lg:flex lg:space-x-8">
-            
-            <main class="w-full lg:w-3/4">
-                <a href="lld_homepage.html" class="text-teal-600 hover:text-teal-800 font-semibold transition-colors duration-200 inline-flex items-center">
-                    <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path></svg>
-                    Return to Homepage
-                </a>
+    <main class="container mx-auto px-4 sm:px-6 lg:px-8 pt-24">
+        <div class="flex justify-between items-center mb-12">
+            <div class="text-center">
+                <h1 class="text-4xl md:text-5xl font-bold tracking-tight text-sienna-800">Day 5: Method Overloading, Overriding & Extension Methods</h1>
+                <p class="mt-4 text-xl text-gray-600">Welcome to Day 5 of our OOP Foundations course. Today, we delve into three powerful C# features that provide flexibility and extensibility to your code: method overloading, method overriding, and extension methods. Mastering these concepts is key to writing clean, intuitive, and maintainable object-oriented programs.</p>
+            </div>
+            <a href="roadmap.html" class="btn btn-primary whitespace-nowrap">Return to Homepage</a>
+        </div>
 
-                <article class="prose max-w-none">
-                    <section id="introduction" class="scroll-mt-20 space-y-4">
+        <div class="flex flex-col lg:flex-row-reverse lg:space-x-reverse lg:space-x-12">
+            <aside class="w-full lg:w-1/4 lg:sticky lg:top-24 self-start mb-12 lg:mb-0">
+                <div class="p-4 rounded-lg bg-white shadow-sm border">
+                    <h3 class="text-lg font-semibold mb-4">On This Page</h3>
+                    <nav id="toc-nav" class="flex flex-col space-y-2">
+                        <a href="#introduction" class="toc-link pl-2 text-gray-600">Introduction</a>
+                        <a href="#theory-topics" class="toc-link pl-2 text-gray-600">Theory Topics</a>
+                        <a href="#coding-practice" class="toc-link pl-2 text-gray-600">Coding Practice & Problems</a>
+                        <a href="#uml-task" class="toc-link pl-2 text-gray-600">UML Task</a>
+                        <a href="#case-study" class="toc-link pl-2 text-gray-600">Case Study: Online Library System APIs</a>
+                        <a href="#knowledge-check" class="toc-link pl-2 text-gray-600">Knowledge Check</a>
+                        <a href="#self-assessment" class="toc-link pl-2 text-gray-600">Self-Assessment Challenge</a>
+                    </nav>
+                </div>
+            </aside>
+
+            <div class="w-full lg:w-3/4 prose-custom">
+                <section id="introduction" class="scroll-mt-20 space-y-4">
                         <h1 class="text-4xl font-bold tracking-tight text-gray-900">Day 5: Method Overloading, Overriding & Extension Methods</h1>
                         <p class="text-lg text-gray-600">Welcome to Day 5 of our OOP Foundations course. Today, we delve into three powerful C# features that provide flexibility and extensibility to your code: method overloading, method overriding, and extension methods. Mastering these concepts is key to writing clean, intuitive, and maintainable object-oriented programs.</p>
                         <div class="bg-indigo-100 border-l-4 border-indigo-500 text-indigo-700 p-4 rounded-r-lg" role="alert">
@@ -559,270 +619,50 @@ public class Program
                             </div>
                         </div>
                     </section>
-                </article>
-
-            </main>
-            <aside class="w-full lg:w-1/4 mb-8 lg:mb-0">
-                <div class="sticky top-8">
-                    <h3 class="text-lg font-semibold text-gray-900 mb-4">On this page</h3>
-                    <nav id="toc" class="flex flex-col space-y-2">
-                    </nav>
-                </div>
-            </aside>
-        </div>
-    </div>
-    
-    <!-- AI Modal -->
-    <div id="ai-modal" class="fixed inset-0 bg-black bg-opacity-50 z-50 hidden items-center justify-center p-4">
-        <div class="bg-white rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] flex flex-col">
-            <div class="p-4 border-b flex justify-between items-center">
-                <h3 id="ai-modal-title" class="text-xl font-semibold">✨ AI Generated Explanation</h3>
-                <button id="ai-modal-close" class="text-gray-500 hover:text-gray-800">&times;</button>
-            </div>
-            <div id="ai-modal-content" class="p-6 overflow-y-auto">
-                <div class="flex items-center justify-center h-48">
-                    <div class="spinner"></div>
-                </div>
             </div>
         </div>
-    </div>
+    </main>
 
-
-    <footer class="text-center mt-16 py-8 border-t border-slate-200">
-        <p class="text-slate-700 font-semibold">Low-Level Design Bootcamp</p>
-        <p class="text-sm text-slate-500 mt-2">A personalized learning roadmap curated by Mr. Mahesh Singare.</p>
-        <p class="text-xs text-slate-400 mt-4">&copy; 2025. All Rights Reserved.</p>
+    <footer class="mt-16 py-8 bg-white border-t">
+        <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
+            <div class="flex justify-center mb-4">
+                <a href="roadmap.html" class="btn btn-primary">Return to Homepage</a>
+            </div>
+            <p class="text-gray-500">&copy; 2025 OOP Foundations. All Rights Reserved.</p>
+            <p class="text-sm mt-1 text-gray-500">A self-contained learning module.</p>
+        </div>
     </footer>
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
     <script>
-        document.addEventListener('DOMContentLoaded', () => {
-
-            const createTOC = () => {
-                const tocContainer = document.getElementById('toc');
-                if (!tocContainer) return;
-                
-                const sections = document.querySelectorAll('main section[id]');
-                let tocHTML = '';
-                sections.forEach(section => {
-                    const h2 = section.querySelector('h2');
-                    if(h2) {
-                        tocHTML += `<a href="#${section.id}" class="toc-link text-gray-600 hover:text-indigo-600 transition-colors duration-200 border-l-2 border-transparent pl-4 py-1">${h2.textContent}</a>`;
-                        
-                        const subSections = section.querySelectorAll('div[id] > h3');
-                        subSections.forEach(sub => {
-                           tocHTML += `<a href="#${sub.parentElement.id}" class="toc-link text-sm text-gray-500 hover:text-indigo-600 transition-colors duration-200 border-l-2 border-transparent pl-8 py-1">${sub.textContent}</a>`;
-                        });
-                    }
+        document.addEventListener('DOMContentLoaded', function () {
+            // --- Copy-to-Clipboard ---
+            document.querySelectorAll('.copy-btn').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    const code = btn.parentElement.querySelector('pre code').innerText;
+                    navigator.clipboard.writeText(code).then(() => {
+                        btn.textContent = 'Copied!';
+                        setTimeout(() => btn.textContent = 'Copy', 2000);
+                    });
                 });
-                tocContainer.innerHTML = tocHTML;
-            };
+            });
 
-            const handleTOCScrolling = () => {
-                const observer = new IntersectionObserver((entries) => {
-                    entries.forEach(entry => {
-                        const id = entry.target.getAttribute('id');
-                        const link = document.querySelector(`.toc-link[href="#${id}"]`);
-                        if (entry.isIntersecting) {
-                            document.querySelectorAll('.toc-link').forEach(l => l.classList.remove('active'));
-                            if (link) {
+            // --- Active TOC Link ---
+            const sections = document.querySelectorAll('main section');
+            const tocLinks = document.querySelectorAll('.toc-link');
+            const observer = new IntersectionObserver(entries => {
+                entries.forEach(entry => {
+                    if (entry.isIntersecting) {
+                        tocLinks.forEach(link => {
+                            link.classList.remove('active');
+                            if (link.getAttribute('href') === `#${entry.target.id}`) {
                                 link.classList.add('active');
                             }
-                        }
-                    });
-                }, { rootMargin: '-20% 0px -70% 0px', threshold: 0.1 });
-
-                document.querySelectorAll('main section[id], main div[id]').forEach(section => {
-                    observer.observe(section);
-                });
-            };
-            
-            const addCodeBlockActions = () => {
-                const codeBlocks = document.querySelectorAll('pre');
-                codeBlocks.forEach(block => {
-                    const actionsContainer = document.createElement('div');
-                    actionsContainer.className = 'code-actions';
-
-                    const copyBtn = document.createElement('button');
-                    copyBtn.innerText = 'Copy';
-                    copyBtn.className = 'code-btn';
-                    
-                    copyBtn.addEventListener('click', () => {
-                        const code = block.querySelector('code').innerText;
-                        navigator.clipboard.writeText(code).then(() => {
-                            copyBtn.innerText = 'Copied!';
-                            setTimeout(() => {
-                                copyBtn.innerText = 'Copy';
-                            }, 2000);
-                        }).catch(err => {
-                            console.error('Failed to copy text: ', err);
                         });
-                    });
-
-                    const explainBtn = document.createElement('button');
-                    explainBtn.innerHTML = '✨ Explain Code';
-                    explainBtn.className = 'code-btn';
-
-                    explainBtn.addEventListener('click', () => {
-                        const code = block.querySelector('code').innerText;
-                        const concept = block.closest('div[id]')?.querySelector('h3')?.textContent || 'this C# code';
-                        const prompt = `Act as an expert C# developer and teacher. Explain the following code snippet step-by-step in a clear, concise way for a beginner. Focus on the concept of "${concept}" if it's relevant.\n\nCode:\n\`\`\`csharp\n${code}\n\`\`\``;
-                        showAiModal('✨ AI Code Explanation', prompt);
-                    });
-                    
-                    actionsContainer.appendChild(explainBtn);
-                    actionsContainer.appendChild(copyBtn);
-                    block.prepend(actionsContainer);
-                });
-            };
-
-            const handleQuiz = () => {
-                const checkButtons = document.querySelectorAll('.quiz-check-btn');
-                checkButtons.forEach(btn => {
-                    btn.addEventListener('click', () => {
-                        const questionId = btn.dataset.question;
-                        const correctAnswer = btn.dataset.answer;
-                        const questionDiv = document.getElementById(`quiz-question-${questionId}`);
-                        const selectedOption = questionDiv.querySelector(`input[name="q${questionId}"]:checked`);
-                        const feedbackDiv = questionDiv.querySelector('.quiz-feedback');
-                        
-                        const correctMessages = {
-                            '1': '<strong>Correct!</strong> Method overriding is about providing a specific implementation in a child class for a method from its parent class.',
-                            '2': '<strong>Correct!</strong> Extension methods must be static, reside in a static class, and use the \'this\' modifier on the first parameter to specify which type they extend.',
-                            '3': '<strong>Correct!</strong> Overloading improves the usability and readability of an API by allowing a single method name to perform the same general action on different sets of inputs.'
-                        };
-
-                        if (!selectedOption) {
-                            feedbackDiv.textContent = 'Please select an answer.';
-                            feedbackDiv.className = 'quiz-feedback mt-2 p-3 rounded-md bg-yellow-100 text-yellow-800';
-                            feedbackDiv.classList.remove('hidden');
-                            return;
-                        }
-
-                        if (selectedOption.value === correctAnswer) {
-                            feedbackDiv.innerHTML = correctMessages[questionId];
-                            feedbackDiv.className = 'quiz-feedback mt-2 p-3 rounded-md bg-green-100 text-green-800';
-                        } else {
-                            feedbackDiv.innerHTML = `<strong>Incorrect.</strong> The correct answer is not (${selectedOption.value}). Please review the theory section and try again.`;
-                            feedbackDiv.className = 'quiz-feedback mt-2 p-3 rounded-md bg-red-100 text-red-800';
-                        }
-                        feedbackDiv.classList.remove('hidden');
-                    });
-                });
-            };
-
-            const handleSolutionToggle = () => {
-                const toggleBtn = document.getElementById('toggle-solution-btn');
-                const solutionCode = document.getElementById('solution-code');
-
-                if (toggleBtn && solutionCode) {
-                    toggleBtn.addEventListener('click', () => {
-                        const isHidden = solutionCode.classList.contains('hidden');
-                        solutionCode.classList.toggle('hidden');
-                        toggleBtn.textContent = isHidden ? 'Hide Solution' : 'Show Solution';
-                        if(!isHidden) Prism.highlightAll();
-                    });
-                }
-            };
-            
-            // --- Gemini API Integration ---
-            const modal = document.getElementById('ai-modal');
-            const modalTitle = document.getElementById('ai-modal-title');
-            const modalContent = document.getElementById('ai-modal-content');
-            const modalCloseBtn = document.getElementById('ai-modal-close');
-            
-            const showAiModal = (title, prompt) => {
-                modalTitle.textContent = title;
-                modalContent.innerHTML = `<div class="flex items-center justify-center h-48"><div class="spinner"></div></div>`;
-                modal.classList.remove('hidden');
-                modal.classList.add('flex');
-                callGemini(prompt);
-            };
-
-            const hideAiModal = () => {
-                modal.classList.add('hidden');
-                modal.classList.remove('flex');
-                modalContent.innerHTML = '';
-            };
-
-            modalCloseBtn.addEventListener('click', hideAiModal);
-            modal.addEventListener('click', (e) => {
-                if (e.target === modal) {
-                    hideAiModal();
-                }
-            });
-            
-            const handleAnalogyButton = () => {
-                const analogyBtn = document.getElementById('analogy-btn');
-                analogyBtn.addEventListener('click', () => {
-                    const prompt = `Explain the difference between method overloading and method overriding in C# using a simple, real-world analogy. Structure the explanation with clear headings for "Method Overloading" and "Method Overriding". Keep it concise and easy for a beginner to understand.`;
-                    showAiModal('✨ AI Generated Analogy', prompt);
-                });
-            };
-            
-            const callGemini = async (prompt, retries = 3, delay = 1000) => {
-                const apiKey = ""; 
-                const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-05-20:generateContent?key=${apiKey}`;
-
-                const payload = {
-                    contents: [{ parts: [{ text: prompt }] }],
-                };
-
-                try {
-                    const response = await fetch(apiUrl, {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify(payload)
-                    });
-
-                    if (!response.ok) {
-                        if (response.status === 429 && retries > 0) {
-                            console.warn(`Rate limited. Retrying in ${delay / 1000}s...`);
-                            await new Promise(res => setTimeout(res, delay));
-                            return callGemini(prompt, retries - 1, delay * 2); 
-                        }
-                        throw new Error(`API call failed with status: ${response.status}`);
                     }
-
-                    const result = await response.json();
-                    const candidate = result.candidates?.[0];
-
-                    if (candidate && candidate.content?.parts?.[0]?.text) {
-                        // Basic markdown to HTML conversion
-                        let htmlContent = candidate.content.parts[0].text
-                            .replace(/```csharp\n([\s\S]*?)```/g, '<pre><code class="language-csharp">$1</code></pre>')
-                            .replace(/```([\s\S]*?)```/g, '<pre><code>$1</code></pre>')
-                            .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
-                            .replace(/\*(.*?)\*/g, '<em>$1</em>')
-                            .replace(/^### (.*$)/gim, '<h3 class="text-xl font-semibold mt-4 mb-2">$1</h3>')
-                            .replace(/^## (.*$)/gim, '<h2 class="text-2xl font-bold mt-6 mb-3">$1</h2>')
-                            .replace(/^#{1} (.*$)/gim, '<h1 class="text-3xl font-bold mt-8 mb-4">$1</h1>')
-                            .replace(/^- (.*$)/gim, '<li class="ml-4">$1</li>')
-                            .replace(/(<li>.*<\/li>)/gs, '<ul>$1</ul>')
-                            .replace(/\n/g, '<br>');
-
-                        modalContent.innerHTML = htmlContent;
-                        Prism.highlightAll();
-                    } else {
-                         throw new Error("Invalid response structure from API.");
-                    }
-                } catch (error) {
-                    console.error("Error calling Gemini API:", error);
-                    modalContent.innerHTML = `<div class="bg-red-100 border-l-4 border-red-500 text-red-700 p-4 rounded-r-lg" role="alert"><p class="font-bold">Error</p><p>Could not retrieve explanation. Please try again later.</p></div>`;
-                }
-            };
-            
-            // --- Initialize Page ---
-            createTOC();
-            handleTOCScrolling();
-            addCodeBlockActions();
-            handleQuiz();
-            handleSolutionToggle();
-            handleAnalogyButton();
-            Prism.highlightAll();
+                });
+            }, { rootMargin: '-40% 0px -60% 0px' });
+            sections.forEach(section => observer.observe(section));
         });
     </script>
 </body>
 </html>
-

--- a/day_6.html
+++ b/day_6.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Day 6: Interfaces & Partial Classes - OOP Foundations</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Roboto+Mono:wght@400;500&display=swap" rel="stylesheet">
@@ -44,14 +43,6 @@
             font-family: 'Roboto Mono', monospace;
             font-size: 0.9em;
         }
-        .token.keyword { color: #569CD6; }
-        .token.type { color: #4EC9B0; }
-        .token.string { color: #CE9178; }
-        .token.comment { color: #6A9955; }
-        .token.method { color: #DCDCAA; }
-        .token.number { color: #B5CEA8; }
-        .token.punctuation { color: #D4D4D4; }
-        .token.variable { color: #9CDCFE; }
         .btn {
             display: inline-block;
             font-weight: 600;
@@ -79,7 +70,8 @@
             padding: 0.25rem 0.5rem;
             border-radius: 0.25rem;
             font-size: 0.75rem;
-            opacity: 0.7;
+            opacity: 0;
+            transition: all 0.2s;
         }
         pre:hover .copy-btn {
             opacity: 1;
@@ -104,15 +96,6 @@
         .prose-custom h2 { margin-top: 2.5em; margin-bottom: 1em; }
         .prose-custom h3 { margin-top: 2em; margin-bottom: 0.8em; }
         .prose-custom p, .prose-custom ul, .prose-custom ol { line-height: 1.7; }
-        .callout {
-            background-color: #F3F4F6;
-            border-left: 4px solid #C06A47;
-            padding: 1rem;
-            border-radius: 0.25rem;
-        }
-        .quiz-option { transition: background-color 0.2s; }
-        .quiz-option.correct { background-color: #C6F6D5; border-color: #38A169; }
-        .quiz-option.incorrect { background-color: #FED7D7; border-color: #E53E3E; }
         .shadow-sm { box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05); }
         .bg-white { background-color: #FFFFFF; }
         .border, .border-t { border-color: #e5e7eb; }
@@ -125,7 +108,7 @@
         <div class="container mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex justify-between items-center py-3">
                 <div class="text-2xl font-bold text-sienna-800">
-                    <a href="lld_homepage.html">OOP Foundations</a>
+                    <a href="roadmap.html">OOP Foundations</a>
                 </div>
                 <nav class="hidden md:flex space-x-4">
                     <a href="day_1.html" class="text-gray-600 hover:text-teal-600 transition">Day 1</a>
@@ -136,21 +119,21 @@
                     <a href="day_6.html" class="font-bold text-teal-600">Day 6</a>
                     <a href="day_7.html" class="text-gray-600 hover:text-teal-600 transition">Day 7</a>
                 </nav>
-                <div class="hidden md:flex">
-                    <a href="lld_homepage.html" class="btn btn-primary">Return to Homepage</a>
-                </div>
+                <!-- Return to Homepage button removed from here -->
             </div>
         </div>
     </header>
 
     <main class="container mx-auto px-4 sm:px-6 lg:px-8 pt-24">
-        <div class="text-center mb-12">
-            <h1 class="text-4xl md:text-5xl font-bold tracking-tight text-sienna-800">Day 6: Interfaces & Partial Classes</h1>
-            <p class="mt-4 text-xl text-gray-600">Exploring contracts and code organization in C# for building flexible and maintainable systems.</p>
+        <div class="flex justify-between items-center mb-12">
+            <div class="text-center">
+                <h1 class="text-4xl md:text-5xl font-bold tracking-tight text-sienna-800">Day 6: Interfaces & Partial Classes</h1>
+                <p class="mt-4 text-xl text-gray-600">Exploring contracts and code organization in C# for building flexible and maintainable systems.</p>
+            </div>
+            <a href="roadmap.html" class="btn btn-primary whitespace-nowrap">Return to Homepage</a>
         </div>
 
         <div class="flex flex-col lg:flex-row-reverse lg:space-x-reverse lg:space-x-12">
-            <!-- Sticky Table of Contents -->
             <aside class="w-full lg:w-1/4 lg:sticky lg:top-24 self-start mb-12 lg:mb-0">
                 <div class="p-4 rounded-lg bg-white shadow-sm border">
                     <h3 class="text-lg font-semibold mb-4">On This Page</h3>
@@ -165,9 +148,8 @@
                 </div>
             </aside>
 
-            <!-- Main Content -->
             <div class="w-full lg:w-3/4 prose-custom">
-                <section id="theory" class="scroll-mt-20">
+                 <section id="theory" class="scroll-mt-20">
                     <h2 class="text-3xl font-bold border-b pb-2">✅ Theory Topics</h2>
                     <p>Today, we dive into two powerful C# features that promote flexible and maintainable code: Interfaces and Partial Classes. Interfaces define contracts that classes must adhere to, enabling polymorphism and decoupling. Partial classes allow a single class definition to be split across multiple files, which is invaluable for code organization and working with auto-generated code.</p>
 
@@ -187,42 +169,42 @@
                     </ul>
 
                     <h5 class="text-lg font-semibold mt-4">Syntax Snippet: Defining an Interface</h5>
-<pre><code class="language-csharp"><span class="token keyword">public</span> <span class="token keyword">interface</span> <span class="token type">IEngine</span>
+<pre><code class="language-csharp">public interface IEngine
 {
-    <span class="token type">void</span> <span class="token method">Start</span>()<span class="token punctuation">;</span>
-    <span class="token type">void</span> <span class="token method">Stop</span>()<span class="token punctuation">;</span>
-    <span class="token type">int</span> <span class="token variable">Horsepower</span> { <span class="token keyword">get</span><span class="token punctuation">;</span> }
+    void Start();
+    void Stop();
+    int Horsepower { get; }
 }
 </code></pre>
 
                     <h5 class="text-lg font-semibold mt-4">Syntax Snippet: Implementing an Interface</h5>
-<pre><code class="language-csharp"><span class="token keyword">public</span> <span class="token keyword">class</span> <span class="token type">ElectricEngine</span> <span class="token punctuation">:</span> <span class="token type">IEngine</span>
+<pre><code class="language-csharp">public class ElectricEngine : IEngine
 {
-    <span class="token keyword">public</span> <span class="token type">int</span> <span class="token variable">Horsepower</span> { <span class="token keyword">get</span><span class="token punctuation">;</span> <span class="token keyword">private</span> <span class="token keyword">set</span><span class="token punctuation">;</span> } <span class="token punctuation">=</span> <span class="token number">250</span><span class="token punctuation">;</span>
+    public int Horsepower { get; private set; } = 250;
 
-    <span class="token keyword">public</span> <span class="token type">void</span> <span class="token method">Start</span>()
+    public void Start()
     {
-        <span class="token type">Console</span><span class="token punctuation">.</span><span class="token method">WriteLine</span>(<span class="token string">"Electric engine hums to life silently."</span>)<span class="token punctuation">;</span>
+        Console.WriteLine("Electric engine hums to life silently.");
     }
 
-    <span class="token keyword">public</span> <span class="token type">void</span> <span class="token method">Stop</span>()
+    public void Stop()
     {
-        <span class="token type">Console</span><span class="token punctuation">.</span><span class="token method">WriteLine</span>(<span class="token string">"Electric engine powers down."</span>)<span class="token punctuation">;</span>
+        Console.WriteLine("Electric engine powers down.");
     }
 }
 
-<span class="token keyword">public</span> <span class="token keyword">class</span> <span class="token type">GasEngine</span> <span class="token punctuation">:</span> <span class="token type">IEngine</span>
+public class GasEngine : IEngine
 {
-    <span class="token keyword">public</span> <span class="token type">int</span> <span class="token variable">Horsepower</span> { <span class="token keyword">get</span><span class="token punctuation">;</span> <span class="token keyword">private</span> <span class="token keyword">set</span><span class="token punctuation">;</span> } <span class="token punctuation">=</span> <span class="token number">180</span><span class="token punctuation">;</span>
+    public int Horsepower { get; private set; } = 180;
     
-    <span class="token keyword">public</span> <span class="token type">void</span> <span class="token method">Start</span>()
+    public void Start()
     {
-        <span class="token type">Console</span><span class="token punctuation">.</span><span class="token method">WriteLine</span>(<span class="token string">"Gas engine roars to life!"</span>)<span class="token punctuation">;</span>
+        Console.WriteLine("Gas engine roars to life!");
     }
 
-    <span class="token keyword">public</span> <span class="token type">void</span> <span class="token method">Stop</span>()
+    public void Stop()
     {
-        <span class="token type">Console</span><span class="token punctuation">.</span><span class="token method">WriteLine</span>(<span class="token string">"Gas engine sputters to a stop."</span>)<span class="token punctuation">;</span>
+        Console.WriteLine("Gas engine sputters to a stop.");
     }
 }
 </code></pre>
@@ -245,18 +227,18 @@
                     <h5 class="text-lg font-semibold mt-4">Syntax Snippet: Defining a Partial Class</h5>
                     <p>Both files must use the <code>partial</code> keyword.</p>
                     <p><strong>File: Employee.cs</strong></p>
-<pre><code class="language-csharp"><span class="token keyword">public</span> <span class="token keyword">partial</span> <span class="token keyword">class</span> <span class="token type">Employee</span>
+<pre><code class="language-csharp">public partial class Employee
 {
-    <span class="token keyword">public</span> <span class="token type">int</span> <span class="token variable">Id</span> { <span class="token keyword">get</span><span class="token punctuation">;</span> <span class="token keyword">set</span><span class="token punctuation">;</span> }
-    <span class="token keyword">public</span> <span class="token type">string</span> <span class="token variable">Name</span> { <span class="token keyword">get</span><span class="token punctuation">;</span> <span class="token keyword">set</span><span class="token punctuation">;</span> }
+    public int Id { get; set; }
+    public string Name { get; set; }
 }
 </code></pre>
                     <p><strong>File: Employee.Logic.cs</strong></p>
-<pre><code class="language-csharp"><span class="token keyword">public</span> <span class="token keyword">partial</span> <span class="token keyword">class</span> <span class="token type">Employee</span>
+<pre><code class="language-csharp">public partial class Employee
 {
-    <span class="token keyword">public</span> <span class="token type">void</span> <span class="token method">Promote</span>()
+    public void Promote()
     {
-        <span class="token type">Console</span><span class="token punctuation">.</span><span class="token method">WriteLine</span>(<span class="token string">$"</span>{<span class="token variable">Name</span>}<span class="token string"> has been promoted!"</span>)<span class="token punctuation">;</span>
+        Console.WriteLine($"{Name} has been promoted!");
     }
 }
 </code></pre>
@@ -267,25 +249,25 @@
 
                     <h4 class="text-xl font-semibold mt-6">The "Fat Interface" Problem</h4>
                     <p>Imagine an interface for a multi-function printer:</p>
-<pre><code class="language-csharp"><span class="token keyword">public</span> <span class="token keyword">interface</span> <span class="token type">IMultiFunctionDevice</span>
+<pre><code class="language-csharp">public interface IMultiFunctionDevice
 {
-    <span class="token type">void</span> <span class="token method">Print</span>()<span class="token punctuation">;</span>
-    <span class="token type">void</span> <span class="token method">Scan</span>()<span class="token punctuation">;</span>
-    <span class="token type">void</span> <span class="token method">Fax</span>()<span class="token punctuation">;</span>
+    void Print();
+    void Scan();
+    void Fax();
 }
 </code></pre>
                     <p>This works fine for a high-end office machine. But what if you have a cheap, print-only printer? It would be forced to implement <code>Scan()</code> and <code>Fax()</code>, likely by throwing a <code>NotImplementedException</code>. This is a design smell.</p>
 
                     <h4 class="text-xl font-semibold mt-6">The ISP Solution</h4>
                     <p>Break the large interface into smaller, more cohesive ones:</p>
-<pre><code class="language-csharp"><span class="token keyword">public</span> <span class="token keyword">interface</span> <span class="token type">IPrinter</span> { <span class="token type">void</span> <span class="token method">Print</span>()<span class="token punctuation">;</span> }
-<span class="token keyword">public</span> <span class="token keyword">interface</span> <span class="token type">IScanner</span> { <span class="token type">void</span> <span class="token method">Scan</span>()<span class="token punctuation">;</span> }
-<span class="token keyword">public</span> <span class="token keyword">interface</span> <span class="token type">IFaxer</span> { <span class="token type">void</span> <span class="token method">Fax</span>()<span class="token punctuation">;</span> }
+<pre><code class="language-csharp">public interface IPrinter { void Print(); }
+public interface IScanner { void Scan(); }
+public interface IFaxer { void Fax(); }
 </code></pre>
                     <p>Now, classes can implement only the interfaces they need:</p>
-<pre><code class="language-csharp"><span class="token keyword">public</span> <span class="token keyword">class</span> <span class="token type">SimplePrinter</span> <span class="token punctuation">:</span> <span class="token type">IPrinter</span> { <span class="token punctuation">...</span> }
-<span class="token keyword">public</span> <span class="token keyword">class</span> <span class="token type">Photocopier</span> <span class="token punctuation">:</span> <span class="token type">IPrinter</span><span class="token punctuation">,</span> <span class="token type">IScanner</span> { <span class="token punctuation">...</span> }
-<span class="token keyword">public</span> <span class="token keyword">class</span> <span class="token type">OfficeHub</span> <span class="token punctuation">:</span> <span class="token type">IPrinter</span><span class="token punctuation">,</span> <span class="token type">IScanner</span><span class="token punctuation">,</span> <span class="token type">IFaxer</span> { <span class="token punctuation">...</span> }
+<pre><code class="language-csharp">public class SimplePrinter : IPrinter { ... }
+public class Photocopier : IPrinter, IScanner { ... }
+public class OfficeHub : IPrinter, IScanner, IFaxer { ... }
 </code></pre>
                     <p>This leads to a much cleaner, more flexible, and decoupled design.</p>
                 </section>
@@ -298,65 +280,65 @@
                     <p>Following the Interface Segregation Principle, define three separate interfaces: <code>IPrint</code>, <code>IScan</code>, and <code>IFax</code>. Then, create a <code>MultiFunctionPrinter</code> class that implements all three and a <code>BasicPrinter</code> that only implements <code>IPrint</code>.</p>
                     
                     <h4 class="text-xl font-semibold mt-4">Solution</h4>
-<pre><code class="language-csharp"><span class="token keyword">using</span> <span class="token type">System</span><span class="token punctuation">;</span>
+<pre><code class="language-csharp">using System;
 
-<span class="token comment">// 1. Define small, specific interfaces</span>
-<span class="token keyword">public</span> <span class="token keyword">interface</span> <span class="token type">IPrint</span>
+// 1. Define small, specific interfaces
+public interface IPrint
 {
-    <span class="token type">void</span> <span class="token method">Print</span>(<span class="token type">string</span> <span class="token variable">document</span>)<span class="token punctuation">;</span>
+    void Print(string document);
 }
 
-<span class="token keyword">public</span> <span class="token keyword">interface</span> <span class="token type">IScan</span>
+public interface IScan
 {
-    <span class="token type">void</span> <span class="token method">Scan</span>(<span class="token type">string</span> <span class="token variable">document</span>)<span class="token punctuation">;</span>
+    void Scan(string document);
 }
 
-<span class="token keyword">public</span> <span class="token keyword">interface</span> <span class="token type">IFax</span>
+public interface IFax
 {
-    <span class="token type">void</span> <span class="token method">Fax</span>(<span class="token type">string</span> <span class="token variable">document</span>)<span class="token punctuation">;</span>
+    void Fax(string document);
 }
 
-<span class="token comment">// 2. Implement all interfaces for a multi-function device</span>
-<span class="token keyword">public</span> <span class="token keyword">class</span> <span class="token type">MultiFunctionPrinter</span> <span class="token punctuation">:</span> <span class="token type">IPrint</span><span class="token punctuation">,</span> <span class="token type">IScan</span><span class="token punctuation">,</span> <span class="token type">IFax</span>
+// 2. Implement all interfaces for a multi-function device
+public class MultiFunctionPrinter : IPrint, IScan, IFax
 {
-    <span class="token keyword">public</span> <span class="token type">void</span> <span class="token method">Print</span>(<span class="token type">string</span> <span class="token variable">document</span>)
+    public void Print(string document)
     {
-        <span class="token type">Console</span><span class="token punctuation">.</span><span class="token method">WriteLine</span>(<span class="token string">$"Printing: </span>{<span class="token variable">document</span>}<span class="token string">"</span>)<span class="token punctuation">;</span>
+        Console.WriteLine($"Printing: {document}");
     }
 
-    <span class="token keyword">public</span> <span class="token type">void</span> <span class="token method">Scan</span>(<span class="token type">string</span> <span class="token variable">document</span>)
+    public void Scan(string document)
     {
-        <span class="token type">Console</span><span class="token punctuation">.</span><span class="token method">WriteLine</span>(<span class="token string">$"Scanning: </span>{<span class="token variable">document</span>}<span class="token string">"</span>)<span class="token punctuation">;</span>
+        Console.WriteLine($"Scanning: {document}");
     }
 
-    <span class="token keyword">public</span> <span class="token type">void</span> <span class="token method">Fax</span>(<span class="token type">string</span> <span class="token variable">document</span>)
+    public void Fax(string document)
     {
-        <span class="token type">Console</span><span class="token punctuation">.</span><span class="token method">WriteLine</span>(<span class="token string">$"Faxing: </span>{<span class="token variable">document</span>}<span class="token string">"</span>)<span class="token punctuation">;</span>
-    }
-}
-
-<span class="token comment">// 3. Implement only the necessary interface for a basic device</span>
-<span class="token keyword">public</span> <span class="token keyword">class</span> <span class="token type">BasicPrinter</span> <span class="token punctuation">:</span> <span class="token type">IPrint</span>
-{
-    <span class="token keyword">public</span> <span class="token type">void</span> <span class="token method">Print</span>(<span class="token type">string</span> <span class="token variable">document</span>)
-    {
-        <span class="token type">Console</span><span class="token punctuation">.</span><span class="token method">WriteLine</span>(<span class="token string">$"Basic Printer Printing: </span>{<span class="token variable">document</span>}<span class="token string">"</span>)<span class="token punctuation">;</span>
+        Console.WriteLine($"Faxing: {document}");
     }
 }
 
-<span class="token keyword">public</span> <span class="token keyword">class</span> <span class="token type">Program</span>
+// 3. Implement only the necessary interface for a basic device
+public class BasicPrinter : IPrint
 {
-    <span class="token keyword">public</span> <span class="token keyword">static</span> <span class="token type">void</span> <span class="token method">Main</span>(<span class="token type">string</span><span class="token punctuation">[]</span> <span class="token variable">args</span>)
+    public void Print(string document)
     {
-        <span class="token type">MultiFunctionPrinter</span> <span class="token variable">mfp</span> <span class="token punctuation">=</span> <span class="token keyword">new</span> <span class="token method">MultiFunctionPrinter</span>()<span class="token punctuation">;</span>
-        <span class="token variable">mfp</span><span class="token punctuation">.</span><span class="token method">Print</span>(<span class="token string">"Annual Report"</span>)<span class="token punctuation">;</span>
-        <span class="token variable">mfp</span><span class="token punctuation">.</span><span class="token method">Scan</span>(<span class="token string">"Invoice"</span>)<span class="token punctuation">;</span>
-        <span class="token variable">mfp</span><span class="token punctuation">.</span><span class="token method">Fax</span>(<span class="token string">"Contract"</span>)<span class="token punctuation">;</span>
+        Console.WriteLine($"Basic Printer Printing: {document}");
+    }
+}
 
-        <span class="token type">Console</span><span class="token punctuation">.</span><span class="token method">WriteLine</span>(<span class="token string">"\n--- Using Basic Printer ---"</span>)<span class="token punctuation">;</span>
-        <span class="token type">BasicPrinter</span> <span class="token variable">bp</span> <span class="token punctuation">=</span> <span class="token keyword">new</span> <span class="token method">BasicPrinter</span>()<span class="token punctuation">;</span>
-        <span class="token variable">bp</span><span class="token punctuation">.</span><span class="token method">Print</span>(<span class="token string">"Shopping List"</span>)<span class="token punctuation">;</span>
-        <span class="token comment">// bp.Scan("Receipt"); // This would cause a compile-time error, which is good!</span>
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        MultiFunctionPrinter mfp = new MultiFunctionPrinter();
+        mfp.Print("Annual Report");
+        mfp.Scan("Invoice");
+        mfp.Fax("Contract");
+
+        Console.WriteLine("\n--- Using Basic Printer ---");
+        BasicPrinter bp = new BasicPrinter();
+        bp.Print("Shopping List");
+        // bp.Scan("Receipt"); // This would cause a compile-time error, which is good!
     }
 }
 </code></pre>
@@ -367,67 +349,67 @@
                     </div>
 
                     <h4 class="text-xl font-semibold mt-4">Solution</h4>
-<pre><code class="language-csharp"><span class="token keyword">using</span> <span class="token type">System</span><span class="token punctuation">;</span>
+<pre><code class="language-csharp">using System;
 
-<span class="token comment">// The contract for all payment processors</span>
-<span class="token keyword">public</span> <span class="token keyword">interface</span> <span class="token type">IPaymentProcessor</span>
+// The contract for all payment processors
+public interface IPaymentProcessor
 {
-    <span class="token type">void</span> <span class="token method">ProcessPayment</span>(<span class="token type">decimal</span> <span class="token variable">amount</span>)<span class="token punctuation">;</span>
+    void ProcessPayment(decimal amount);
 }
 
-<span class="token comment">// Concrete implementation for PayPal</span>
-<span class="token keyword">public</span> <span class="token keyword">class</span> <span class="token type">PayPalProcessor</span> <span class="token punctuation">:</span> <span class="token type">IPaymentProcessor</span>
+// Concrete implementation for PayPal
+public class PayPalProcessor : IPaymentProcessor
 {
-    <span class="token keyword">public</span> <span class="token type">void</span> <span class="token method">ProcessPayment</span>(<span class="token type">decimal</span> <span class="token variable">amount</span>)
+    public void ProcessPayment(decimal amount)
     {
-        <span class="token type">Console</span><span class="token punctuation">.</span><span class="token method">WriteLine</span>(<span class="token string">$"Processing $</span>{<span class="token variable">amount</span>}<span class="token string"> payment via PayPal."</span>)<span class="token punctuation">;</span>
-        <span class="token comment">// Logic to interact with PayPal API would go here</span>
+        Console.WriteLine($"Processing ${amount} payment via PayPal.");
+        // Logic to interact with PayPal API would go here
     }
 }
 
-<span class="token comment">// Concrete implementation for Stripe</span>
-<span class="token keyword">public</span> <span class="token keyword">class</span> <span class="token type">StripeProcessor</span> <span class="token punctuation">:</span> <span class="token type">IPaymentProcessor</span>
+// Concrete implementation for Stripe
+public class StripeProcessor : IPaymentProcessor
 {
-    <span class="token keyword">public</span> <span class="token type">void</span> <span class="token method">ProcessPayment</span>(<span class="token type">decimal</span> <span class="token variable">amount</span>)
+    public void ProcessPayment(decimal amount)
     {
-        <span class="token type">Console</span><span class="token punctuation">.</span><span class="token method">WriteLine</span>(<span class="token string">$"Processing $</span>{<span class="token variable">amount</span>}<span class="token string"> payment via Stripe."</span>)<span class="token punctuation">;</span>
-        <span class="token comment">// Logic to interact with Stripe API would go here</span>
+        Console.WriteLine($"Processing ${amount} payment via Stripe.");
+        // Logic to interact with Stripe API would go here
     }
 }
 
-<span class="token comment">// The Factory class to create processor objects</span>
-<span class="token keyword">public</span> <span class="token keyword">static</span> <span class="token keyword">class</span> <span class="token type">PaymentFactory</span>
+// The Factory class to create processor objects
+public static class PaymentFactory
 {
-    <span class="token keyword">public</span> <span class="token keyword">static</span> <span class="token type">IPaymentProcessor</span> <span class="token method">GetPaymentProcessor</span>(<span class="token type">string</span> <span class="token variable">processorType</span>)
+    public static IPaymentProcessor GetPaymentProcessor(string processorType)
     {
-        <span class="token keyword">switch</span> (<span class="token variable">processorType</span><span class="token punctuation">.</span><span class="token method">ToLower</span>())
+        switch (processorType.ToLower())
         {
-            <span class="token keyword">case</span> <span class="token string">"paypal"</span><span class="token punctuation">:</span>
-                <span class="token keyword">return</span> <span class="token keyword">new</span> <span class="token method">PayPalProcessor</span>()<span class="token punctuation">;</span>
-            <span class="token keyword">case</span> <span class="token string">"stripe"</span><span class="token punctuation">:</span>
-                <span class="token keyword">return</span> <span class="token keyword">new</span> <span class="token method">StripeProcessor</span>()<span class="token punctuation">;</span>
-            <span class="token keyword">default</span><span class="token punctuation">:</span>
-                <span class="token keyword">throw</span> <span class="token keyword">new</span> <span class="token method">ArgumentException</span>(<span class="token string">"Invalid payment processor type"</span><span class="token punctuation">,</span> <span class="token keyword">nameof</span>(<span class="token variable">processorType</span>))<span class="token punctuation">;</span>
+            case "paypal":
+                return new PayPalProcessor();
+            case "stripe":
+                return new StripeProcessor();
+            default:
+                throw new ArgumentException("Invalid payment processor type", nameof(processorType));
         }
     }
 }
 
-<span class="token comment">// Client code that uses the factory</span>
-<span class="token keyword">public</span> <span class="token keyword">class</span> <span class="token type">Program</span>
+// Client code that uses the factory
+public class Program
 {
-    <span class="token keyword">public</span> <span class="token keyword">static</span> <span class="token type">void</span> <span class="token method">Main</span>(<span class="token type">string</span><span class="token punctuation">[]</span> <span class="token variable">args</span>)
+    public static void Main(string[] args)
     {
-        <span class="token comment">// The client code doesn't need to know about the concrete classes.</span>
-        <span class="token comment">// It just requests a processor from the factory.</span>
+        // The client code doesn't need to know about the concrete classes.
+        // It just requests a processor from the factory.
         
-        <span class="token type">string</span> <span class="token variable">paymentMethod</span> <span class="token punctuation">=</span> <span class="token string">"stripe"</span><span class="token punctuation">;</span> <span class="token comment">// This could come from user input or a config file</span>
+        string paymentMethod = "stripe"; // This could come from user input or a config file
         
-        <span class="token type">IPaymentProcessor</span> <span class="token variable">processor</span> <span class="token punctuation">=</span> <span class="token type">PaymentFactory</span><span class="token punctuation">.</span><span class="token method">GetPaymentProcessor</span>(<span class="token variable">paymentMethod</span>)<span class="token punctuation">;</span>
-        <span class="token variable">processor</span><span class="token punctuation">.</span><span class="token method">ProcessPayment</span>(<span class="token number">99.99m</span>)<span class="token punctuation">;</span>
+        IPaymentProcessor processor = PaymentFactory.GetPaymentProcessor(paymentMethod);
+        processor.ProcessPayment(99.99m);
 
-        <span class="token variable">paymentMethod</span> <span class="token punctuation">=</span> <span class="token string">"paypal"</span><span class="token punctuation">;</span>
-        <span class="token variable">processor</span> <span class="token punctuation">=</span> <span class="token type">PaymentFactory</span><span class="token punctuation">.</span><span class="token method">GetPaymentProcessor</span>(<span class="token variable">paymentMethod</span>)<span class="token punctuation">;</span>
-        <span class="token variable">processor</span><span class="token punctuation">.</span><span class="token method">ProcessPayment</span>(<span class="token number">12.50m</span>)<span class="token punctuation">;</span>
+        paymentMethod = "paypal";
+        processor = PaymentFactory.GetPaymentProcessor(paymentMethod);
+        processor.ProcessPayment(12.50m);
     }
 }
 </code></pre>
@@ -501,101 +483,101 @@
                     <p>This design is highly modular. If we need to add a new notification method tomorrow (like Slack or Teams), we just need to create a new class that implements <code>IMessageSender</code> and update the factory. The <code>NotificationService</code> client code remains completely unchanged.</p>
 
                     <h5 class="text-lg font-semibold mt-4">1. The `IMessageSender` Interface (The Contract)</h5>
-<pre><code class="language-csharp"><span class="token keyword">public</span> <span class="token keyword">interface</span> <span class="token type">IMessageSender</span>
+<pre><code class="language-csharp">public interface IMessageSender
 {
-    <span class="token type">void</span> <span class="token method">SendMessage</span>(<span class="token type">string</span> <span class="token variable">recipient</span>, <span class="token type">string</span> <span class="token variable">message</span>)<span class="token punctuation">;</span>
+    void SendMessage(string recipient, string message);
 }
 </code></pre>
 
                     <h5 class="text-lg font-semibold mt-4">2. Concrete Implementations</h5>
-<pre><code class="language-csharp"><span class="token keyword">using</span> <span class="token type">System</span><span class="token punctuation">;</span>
+<pre><code class="language-csharp">using System;
 
-<span class="token keyword">public</span> <span class="token keyword">class</span> <span class="token type">EmailSender</span> <span class="token punctuation">:</span> <span class="token type">IMessageSender</span>
+public class EmailSender : IMessageSender
 {
-    <span class="token keyword">public</span> <span class="token type">void</span> <span class="token method">SendMessage</span>(<span class="token type">string</span> <span class="token variable">recipient</span>, <span class="token type">string</span> <span class="token variable">message</span>)
+    public void SendMessage(string recipient, string message)
     {
-        <span class="token type">Console</span><span class="token punctuation">.</span><span class="token method">WriteLine</span>(<span class="token string">$"--- EMAIL ---"</span>)<span class="token punctuation">;</span>
-        <span class="token type">Console</span><span class="token punctuation">.</span><span class="token method">WriteLine</span>(<span class="token string">$"To: </span>{<span class="token variable">recipient</span>}<span class="token string">"</span>)<span class="token punctuation">;</span>
-        <span class="token type">Console</span><span class="token punctuation">.</span><span class="token method">WriteLine</span>(<span class="token string">$"Body: </span>{<span class="token variable">message</span>}<span class="token string">"</span>)<span class="token punctuation">;</span>
-        <span class="token type">Console</span><span class="token punctuation">.</span><span class="token method">WriteLine</span>(<span class="token string">$"Email sent successfully.\n"</span>)<span class="token punctuation">;</span>
+        Console.WriteLine($"--- EMAIL ---");
+        Console.WriteLine($"To: {recipient}");
+        Console.WriteLine($"Body: {message}");
+        Console.WriteLine($"Email sent successfully.\n");
     }
 }
 
-<span class="token keyword">public</span> <span class="token keyword">class</span> <span class="token type">SmsSender</span> <span class="token punctuation">:</span> <span class="token type">IMessageSender</span>
+public class SmsSender : IMessageSender
 {
-    <span class="token keyword">public</span> <span class="token type">void</span> <span class="token method">SendMessage</span>(<span class="token type">string</span> <span class="token variable">recipient</span>, <span class="token type">string</span> <span class="token variable">message</span>)
+    public void SendMessage(string recipient, string message)
     {
-        <span class="token type">Console</span><span class="token punctuation">.</span><span class="token method">WriteLine</span>(<span class="token string">$"--- SMS ---"</span>)<span class="token punctuation">;</span>
-        <span class="token type">Console</span><span class="token punctuation">.</span><span class="token method">WriteLine</span>(<span class="token string">$"To Phone Number: </span>{<span class="token variable">recipient</span>}<span class="token string">"</span>)<span class="token punctuation">;</span>
-        <span class="token type">Console</span><span class="token punctuation">.</span><span class="token method">WriteLine</span>(<span class="token string">$"Message: </span>{<span class="token variable">message</span>}<span class="token string">"</span>)<span class="token punctuation">;</span>
-        <span class="token type">Console</span><span class="token punctuation">.</span><span class="token method">WriteLine</span>(<span class="token string">$"SMS sent successfully.\n"</span>)<span class="token punctuation">;</span>
+        Console.WriteLine($"--- SMS ---");
+        Console.WriteLine($"To Phone Number: {recipient}");
+        Console.WriteLine($"Message: {message}");
+        Console.WriteLine($"SMS sent successfully.\n");
     }
 }
 
-<span class="token keyword">public</span> <span class="token keyword">class</span> <span class="token type">PushNotificationSender</span> <span class="token punctuation">:</span> <span class="token type">IMessageSender</span>
+public class PushNotificationSender : IMessageSender
 {
-    <span class="token keyword">public</span> <span class="token type">void</span> <span class="token method">SendMessage</span>(<span class="token type">string</span> <span class="token variable">recipient</span>, <span class="token type">string</span> <span class="token variable">message</span>)
+    public void SendMessage(string recipient, string message)
     {
-        <span class="token type">Console</span><span class="token punctuation">.</span><span class="token method">WriteLine</span>(<span class="token string">$"--- PUSH NOTIFICATION ---"</span>)<span class="token punctuation">;</span>
-        <span class="token type">Console</span><span class="token punctuation">.</span><span class="token method">WriteLine</span>(<span class="token string">$"To Device Token: </span>{<span class="token variable">recipient</span>}<span class="token string">"</span>)<span class="token punctuation">;</span>
-        <span class="token type">Console</span><span class="token punctuation">.</span><span class="token method">WriteLine</span>(<span class="token string">$"Notification: </span>{<span class="token variable">message</span>}<span class="token string">"</span>)<span class="token punctuation">;</span>
-        <span class="token type">Console</span><span class="token punctuation">.</span><span class="token method">WriteLine</span>(<span class="token string">$"Push notification sent successfully.\n"</span>)<span class="token punctuation">;</span>
+        Console.WriteLine($"--- PUSH NOTIFICATION ---");
+        Console.WriteLine($"To Device Token: {recipient}");
+        Console.WriteLine($"Notification: {message}");
+        Console.WriteLine($"Push notification sent successfully.\n");
     }
 }
 </code></pre>
                     <h5 class="text-lg font-semibold mt-4">3. The `MessageSenderFactory`</h5>
-<pre><code class="language-csharp"><span class="token keyword">using</span> <span class="token type">System</span><span class="token punctuation">;</span>
+<pre><code class="language-csharp">using System;
 
-<span class="token keyword">public</span> <span class="token keyword">static</span> <span class="token keyword">class</span> <span class="token type">MessageSenderFactory</span>
+public static class MessageSenderFactory
 {
-    <span class="token keyword">public</span> <span class="token keyword">static</span> <span class="token type">IMessageSender</span> <span class="token method">GetSender</span>(<span class="token type">string</span> <span class="token variable">type</span>)
+    public static IMessageSender GetSender(string type)
     {
-        <span class="token keyword">return</span> <span class="token variable">type</span><span class="token punctuation">.</span><span class="token method">ToLower</span>() <span class="token keyword">switch</span>
+        return type.ToLower() switch
         {
-            <span class="token string">"email"</span> <span class="token punctuation">=></span> <span class="token keyword">new</span> <span class="token method">EmailSender</span>()<span class="token punctuation">,</span>
-            <span class="token string">"sms"</span> <span class="token punctuation">=></span> <span class="token keyword">new</span> <span class="token method">SmsSender</span>()<span class="token punctuation">,</span>
-            <span class="token string">"push"</span> <span class="token punctuation">=></span> <span class="token keyword">new</span> <span class="token method">PushNotificationSender</span>()<span class="token punctuation">,</span>
-            <span class="token variable">_</span> <span class="token punctuation">=></span> <span class="token keyword">throw</span> <span class="token keyword">new</span> <span class="token method">ArgumentException</span>(<span class="token string">"Invalid sender type specified."</span>)<span class="token punctuation">,</span>
-        }<span class="token punctuation">;</span>
+            "email" => new EmailSender(),
+            "sms" => new SmsSender(),
+            "push" => new PushNotificationSender(),
+            _ => throw new ArgumentException("Invalid sender type specified."),
+        };
     }
 }
 </code></pre>
                     <h5 class="text-lg font-semibold mt-4">4. Client Code: `NotificationService`</h5>
-<pre><code class="language-csharp"><span class="token keyword">using</span> <span class="token type">System</span><span class="token punctuation">;</span>
+<pre><code class="language-csharp">using System;
 
-<span class="token keyword">public</span> <span class="token keyword">class</span> <span class="token type">NotificationService</span>
+public class NotificationService
 {
-    <span class="token keyword">public</span> <span class="token type">void</span> <span class="token method">SendNotification</span>(<span class="token type">string</span> <span class="token variable">type</span>, <span class="token type">string</span> <span class="token variable">recipient</span>, <span class="token type">string</span> <span class="token variable">message</span>)
+    public void SendNotification(string type, string recipient, string message)
     {
-        <span class="token keyword">try</span>
+        try
         {
-            <span class="token type">IMessageSender</span> <span class="token variable">sender</span> <span class="token punctuation">=</span> <span class="token type">MessageSenderFactory</span><span class="token punctuation">.</span><span class="token method">GetSender</span>(<span class="token variable">type</span>)<span class="token punctuation">;</span>
-            <span class="token variable">sender</span><span class="token punctuation">.</span><span class="token method">SendMessage</span>(<span class="token variable">recipient</span>, <span class="token variable">message</span>)<span class="token punctuation">;</span>
+            IMessageSender sender = MessageSenderFactory.GetSender(type);
+            sender.SendMessage(recipient, message);
         }
-        <span class="token keyword">catch</span> (<span class="token type">ArgumentException</span> <span class="token variable">ex</span>)
+        catch (ArgumentException ex)
         {
-            <span class="token type">Console</span><span class="token punctuation">.</span><span class="token method">WriteLine</span>(<span class="token string">$"Error: </span>{<span class="token variable">ex</span><span class="token punctuation">.</span><span class="token variable">Message</span>}<span class="token string">"</span>)<span class="token punctuation">;</span>
+            Console.WriteLine($"Error: {ex.Message}");
         }
     }
 }
 
-<span class="token keyword">public</span> <span class="token keyword">class</span> <span class="token type">Program</span>
+public class Program
 {
-    <span class="token keyword">public</span> <span class="token keyword">static</span> <span class="token type">void</span> <span class="token method">Main</span>(<span class="token type">string</span><span class="token punctuation">[]</span> <span class="token variable">args</span>)
+    public static void Main(string[] args)
     {
-        <span class="token type">NotificationService</span> <span class="token variable">notificationService</span> <span class="token punctuation">=</span> <span class="token keyword">new</span> <span class="token method">NotificationService</span>()<span class="token punctuation">;</span>
+        NotificationService notificationService = new NotificationService();
 
-        <span class="token comment">// Send an email</span>
-        <span class="token variable">notificationService</span><span class="token punctuation">.</span><span class="token method">SendNotification</span>(<span class="token string">"email"</span>, <span class="token string">"test@example.com"</span>, <span class="token string">"Your order has shipped!"</span>)<span class="token punctuation">;</span>
+        // Send an email
+        notificationService.SendNotification("email", "test@example.com", "Your order has shipped!");
 
-        <span class="token comment">// Send an SMS</span>
-        <span class="token variable">notificationService</span><span class="token punctuation">.</span><span class="token method">SendNotification</span>(<span class="token string">"sms"</span>, <span class="token string">"+15551234567"</span>, <span class="token string">"Your package is out for delivery."</span>)<span class="token punctuation">;</span>
+        // Send an SMS
+        notificationService.SendNotification("sms", "+15551234567", "Your package is out for delivery.");
 
-        <span class="token comment">// Send a push notification</span>
-        <span class="token variable">notificationService</span><span class="token punctuation">.</span><span class="token method">SendNotification</span>(<span class="token string">"push"</span>, <span class="token string">"device_token_abc123"</span>, <span class="token string">"You have a new friend request."</span>)<span class="token punctuation">;</span>
+        // Send a push notification
+        notificationService.SendNotification("push", "device_token_abc123", "You have a new friend request.");
         
-        <span class="token comment">// Try to send an invalid type</span>
-        <span class="token variable">notificationService</span><span class="token punctuation">.</span><span class="token method">SendNotification</span>(<span class="token string">"telegram"</span>, <span class="token string">"user_id_xyz"</span>, <span class="token string">"This will fail."</span>)<span class="token punctuation">;</span>
+        // Try to send an invalid type
+        notificationService.SendNotification("telegram", "user_id_xyz", "This will fail.");
     }
 }
 </code></pre>
@@ -628,105 +610,105 @@
                         <button id="toggle-solution-btn" class="btn btn-primary">Show Solution</button>
                         <div id="solution-content" class="hidden mt-4">
                             <h4 class="text-xl font-semibold">Challenge Solution</h4>
-<pre><code class="language-csharp"><span class="token keyword">using</span> <span class="token type">System</span><span class="token punctuation">;</span>
-<span class="token keyword">using</span> <span class="token type">System<span class="token punctuation">.</span>Collections<span class="token punctuation">.</span>Generic</span><span class="token punctuation">;</span>
+<pre><code class="language-csharp">using System;
+using System.Collections.Generic;
 
-<span class="token comment">// --- Data Model ---</span>
-<span class="token keyword">public</span> <span class="token keyword">class</span> <span class="token type">User</span>
+// --- Data Model ---
+public class User
 {
-    <span class="token keyword">public</span> <span class="token type">int</span> <span class="token variable">Id</span> { <span class="token keyword">get</span><span class="token punctuation">;</span> <span class="token keyword">set</span><span class="token punctuation">;</span> }
-    <span class="token keyword">public</span> <span class="token type">string</span> <span class="token variable">Username</span> { <span class="token keyword">get</span><span class="token punctuation">;</span> <span class="token keyword">set</span><span class="token punctuation">;</span> }
-    <span class="token keyword">public</span> <span class="token type">string</span> <span class="token variable">Email</span> { <span class="token keyword">get</span><span class="token punctuation">;</span> <span class="token keyword">set</span><span class="token punctuation">;</span> }
+    public int Id { get; set; }
+    public string Username { get; set; }
+    public string Email { get; set; }
 }
 
-<span class="token comment">// --- Interfaces ---</span>
-<span class="token keyword">public</span> <span class="token keyword">interface</span> <span class="token type">IDataExporter</span>
+// --- Interfaces ---
+public interface IDataExporter
 {
-    <span class="token type">string</span> <span class="token method">Export</span>(<span class="token type">IEnumerable</span><span class="token punctuation">&lt;</span><span class="token type">User</span><span class="token punctuation">&gt;</span> <span class="token variable">data</span>)<span class="token punctuation">;</span>
+    string Export(IEnumerable&lt;User&gt; data);
 }
 
-<span class="token comment">// --- Concrete Implementations ---</span>
-<span class="token keyword">public</span> <span class="token keyword">class</span> <span class="token type">CsvExporter</span> <span class="token punctuation">:</span> <span class="token type">IDataExporter</span>
+// --- Concrete Implementations ---
+public class CsvExporter : IDataExporter
 {
-    <span class="token keyword">public</span> <span class="token type">string</span> <span class="token method">Export</span>(<span class="token type">IEnumerable</span><span class="token punctuation">&lt;</span><span class="token type">User</span><span class="token punctuation">&gt;</span> <span class="token variable">data</span>)
+    public string Export(IEnumerable&lt;User&gt; data)
     {
-        <span class="token type">Console</span><span class="token punctuation">.</span><span class="token method">WriteLine</span>(<span class="token string">"Exporting data to CSV format..."</span>)<span class="token punctuation">;</span>
-        <span class="token keyword">var</span> <span class="token variable">lines</span> <span class="token punctuation">=</span> <span class="token keyword">new</span> <span class="token method">List</span><span class="token punctuation">&lt;</span><span class="token type">string</span><span class="token punctuation">&gt;</span> { <span class="token string">"Id,Username,Email"</span> }<span class="token punctuation">;</span>
-        <span class="token keyword">foreach</span> (<span class="token keyword">var</span> <span class="token variable">user</span> <span class="token keyword">in</span> <span class="token variable">data</span>)
+        Console.WriteLine("Exporting data to CSV format...");
+        var lines = new List&lt;string&gt; { "Id,Username,Email" };
+        foreach (var user in data)
         {
-            <span class="token variable">lines</span><span class="token punctuation">.</span><span class="token method">Add</span>(<span class="token string">$"</span>{<span class="token variable">user</span><span class="token punctuation">.</span><span class="token variable">Id</span>}<span class="token string">,</span>{<span class="token variable">user</span><span class="token punctuation">.</span><span class="token variable">Username</span>}<span class="token string">,</span>{<span class="token variable">user</span><span class="token punctuation">.</span><span class="token variable">Email</span>}<span class="token string">"</span>)<span class="token punctuation">;</span>
+            lines.Add($"{user.Id},{user.Username},{user.Email}");
         }
-        <span class="token keyword">return</span> <span class="token type">string</span><span class="token punctuation">.</span><span class="token method">Join</span>(<span class="token string">"\n"</span>, <span class="token variable">lines</span>)<span class="token punctuation">;</span>
+        return string.Join("\n", lines);
     }
 }
 
-<span class="token keyword">public</span> <span class="token keyword">class</span> <span class="token type">JsonExporter</span> <span class="token punctuation">:</span> <span class="token type">IDataExporter</span>
+public class JsonExporter : IDataExporter
 {
-    <span class="token keyword">public</span> <span class="token type">string</span> <span class="token method">Export</span>(<span class="token type">IEnumerable</span><span class="token punctuation">&lt;</span><span class="token type">User</span><span class="token punctuation">&gt;</span> <span class="token variable">data</span>)
+    public string Export(IEnumerable&lt;User&gt; data)
     {
-        <span class="token type">Console</span><span class="token punctuation">.</span><span class="token method">WriteLine</span>(<span class="token string">"Exporting data to JSON format..."</span>)<span class="token punctuation">;</span>
-        <span class="token keyword">var</span> <span class="token variable">userStrings</span> <span class="token punctuation">=</span> <span class="token keyword">new</span> <span class="token method">List</span><span class="token punctuation">&lt;</span><span class="token type">string</span><span class="token punctuation">&gt;</span>()<span class="token punctuation">;</span>
-        <span class="token keyword">foreach</span> (<span class="token keyword">var</span> <span class="token variable">user</span> <span class="token keyword">in</span> <span class="token variable">data</span>)
+        Console.WriteLine("Exporting data to JSON format...");
+        var userStrings = new List&lt;string&gt;();
+        foreach (var user in data)
         {
-            <span class="token variable">userStrings</span><span class="token punctuation">.</span><span class="token method">Add</span>(<span class="token string">$"  {{\n    \"Id\": </span>{<span class="token variable">user</span><span class="token punctuation">.</span><span class="token variable">Id</span>}<span class="token string">,\n    \"Username\": \"</span>{<span class="token variable">user</span><span class="token punctuation">.</span><span class="token variable">Username</span>}<span class="token string">\",\n    \"Email\": \"</span>{<span class="token variable">user</span><span class="token punctuation">.</span><span class="token variable">Email</span>}<span class="token string">\"\n  }}"</span>)<span class="token punctuation">;</span>
+            userStrings.Add($"  {{\n    \"Id\": {user.Id},\n    \"Username\": \"{user.Username}\",\n    \"Email\": \"{user.Email}\"\n  }}");
         }
-        <span class="token keyword">return</span> <span class="token string">"[\n"</span> <span class="token punctuation">+</span> <span class="token type">string</span><span class="token punctuation">.</span><span class="token method">Join</span>(<span class="token string">",\n"</span>, <span class="token variable">userStrings</span>) <span class="token punctuation">+</span> <span class="token string">"\n]"</span><span class="token punctuation">;</span>
+        return "[\n" + string.Join(",\n", userStrings) + "\n]";
     }
 }
 
-<span class="token keyword">public</span> <span class="token keyword">class</span> <span class="token type">XmlExporter</span> <span class="token punctuation">:</span> <span class="token type">IDataExporter</span>
+public class XmlExporter : IDataExporter
 {
-    <span class="token keyword">public</span> <span class="token type">string</span> <span class="token method">Export</span>(<span class="token type">IEnumerable</span><span class="token punctuation">&lt;</span><span class="token type">User</span><span class="token punctuation">&gt;</span> <span class="token variable">data</span>)
+    public string Export(IEnumerable&lt;User&gt; data)
     {
-        <span class="token type">Console</span><span class="token punctuation">.</span><span class="token method">WriteLine</span>(<span class="token string">"Exporting data to XML format..."</span>)<span class="token punctuation">;</span>
-        <span class="token keyword">var</span> <span class="token variable">userElements</span> <span class="token punctuation">=</span> <span class="token keyword">new</span> <span class="token method">List</span><span class="token punctuation">&lt;</span><span class="token type">string</span><span class="token punctuation">&gt;</span>()<span class="token punctuation">;</span>
-        <span class="token keyword">foreach</span> (<span class="token keyword">var</span> <span class="token variable">user</span> <span class="token keyword">in</span> <span class="token variable">data</span>)
+        Console.WriteLine("Exporting data to XML format...");
+        var userElements = new List&lt;string&gt;();
+        foreach (var user in data)
         {
-            <span class="token variable">userElements</span><span class="token punctuation">.</span><span class="token method">Add</span>(<span class="token string">$"  &lt;User&gt;\n    &lt;Id&gt;</span>{<span class="token variable">user</span><span class="token punctuation">.</span><span class="token variable">Id</span>}<span class="token string">&lt;/Id&gt;\n    &lt;Username&gt;</span>{<span class="token variable">user</span><span class="token punctuation">.</span><span class="token variable">Username</span>}<span class="token string">&lt;/Username&gt;\n    &lt;Email&gt;</span>{<span class="token variable">user</span><span class="token punctuation">.</span><span class="token variable">Email</span>}<span class="token string">&lt;/Email&gt;\n  &lt;/User&gt;"</span>)<span class="token punctuation">;</span>
+            userElements.Add($"  &lt;User&gt;\n    &lt;Id&gt;{user.Id}&lt;/Id&gt;\n    &lt;Username&gt;{user.Username}&lt;/Username&gt;\n    &lt;Email&gt;{user.Email}&lt;/Email&gt;\n  &lt;/User&gt;");
         }
-        <span class="token keyword">return</span> <span class="token string">"&lt;Users&gt;\n"</span> <span class="token punctuation">+</span> <span class="token type">string</span><span class="token punctuation">.</span><span class="token method">Join</span>(<span class="token string">"\n"</span>, <span class="token variable">userElements</span>) <span class="token punctuation">+</span> <span class="token string">"\n&lt;/Users&gt;"</span><span class="token punctuation">;</span>
+        return "&lt;Users&gt;\n" + string.Join("\n", userElements) + "\n&lt;/Users&gt;";
     }
 }
 
-<span class="token comment">// --- Factory ---</span>
-<span class="token keyword">public</span> <span class="token keyword">static</span> <span class="token keyword">class</span> <span class="token type">ExporterFactory</span>
+// --- Factory ---
+public static class ExporterFactory
 {
-    <span class="token keyword">public</span> <span class="token keyword">static</span> <span class="token type">IDataExporter</span> <span class="token method">GetExporter</span>(<span class="token type">string</span> <span class="token variable">format</span>)
+    public static IDataExporter GetExporter(string format)
     {
-        <span class="token keyword">return</span> <span class="token variable">format</span><span class="token punctuation">.</span><span class="token method">ToLower</span>() <span class="token keyword">switch</span>
+        return format.ToLower() switch
         {
-            <span class="token string">"csv"</span> <span class="token punctuation">=></span> <span class="token keyword">new</span> <span class="token method">CsvExporter</span>()<span class="token punctuation">,</span>
-            <span class="token string">"json"</span> <span class="token punctuation">=></span> <span class="token keyword">new</span> <span class="token method">JsonExporter</span>()<span class="token punctuation">,</span>
-            <span class="token string">"xml"</span> <span class="token punctuation">=></span> <span class="token keyword">new</span> <span class="token method">XmlExporter</span>()<span class="token punctuation">,</span>
-            <span class="token variable">_</span> <span class="token punctuation">=></span> <span class="token keyword">throw</span> <span class="token keyword">new</span> <span class="token method">NotSupportedException</span>(<span class="token string">$"Format '</span>{<span class="token variable">format</span>}<span class="token string">' is not supported."</span>)<span class="token punctuation">,</span>
-        }<span class="token punctuation">;</span>
+            "csv" => new CsvExporter(),
+            "json" => new JsonExporter(),
+            "xml" => new XmlExporter(),
+            _ => throw new NotSupportedException($"Format '{format}' is not supported."),
+        };
     }
 }
 
-<span class="token comment">// --- Client ---</span>
-<span class="token keyword">public</span> <span class="token keyword">class</span> <span class="token type">Program</span>
+// --- Client ---
+public class Program
 {
-    <span class="token keyword">public</span> <span class="token keyword">static</span> <span class="token type">void</span> <span class="token method">Main</span>()
+    public static void Main()
     {
-        <span class="token keyword">var</span> <span class="token variable">users</span> <span class="token punctuation">=</span> <span class="token keyword">new</span> <span class="token method">List</span><span class="token punctuation">&lt;</span><span class="token type">User</span><span class="token punctuation">&gt;</span>
+        var users = new List&lt;User&gt;
         {
-            <span class="token keyword">new</span> <span class="token type">User</span> { <span class="token variable">Id</span> <span class="token punctuation">=</span> <span class="token number">1</span>, <span class="token variable">Username</span> <span class="token punctuation">=</span> <span class="token string">"alice"</span>, <span class="token variable">Email</span> <span class="token punctuation">=</span> <span class="token string">"alice@example.com"</span> }<span class="token punctuation">,</span>
-            <span class="token keyword">new</span> <span class="token type">User</span> { <span class="token variable">Id</span> <span class="token punctuation">=</span> <span class="token number">2</span>, <span class="token variable">Username</span> <span class="token punctuation">=</span> <span class="token string">"bob"</span>, <span class="token variable">Email</span> <span class="token punctuation">=</span> <span class="token string">"bob@example.com"</span> }
-        }<span class="token punctuation">;</span>
+            new User { Id = 1, Username = "alice", Email = "alice@example.com" },
+            new User { Id = 2, Username = "bob", Email = "bob@example.com" }
+        };
 
-        <span class="token type">string</span><span class="token punctuation">[]</span> <span class="token variable">formats</span> <span class="token punctuation">=</span> { <span class="token string">"csv"</span><span class="token punctuation">,</span> <span class="token string">"json"</span><span class="token punctuation">,</span> <span class="token string">"xml"</span> }<span class="token punctuation">;</span>
+        string[] formats = { "csv", "json", "xml" };
 
-        <span class="token keyword">foreach</span> (<span class="token keyword">var</span> <span class="token variable">format</span> <span class="token keyword">in</span> <span class="token variable">formats</span>)
+        foreach (var format in formats)
         {
-            <span class="token keyword">try</span>
+            try
             {
-                <span class="token type">IDataExporter</span> <span class="token variable">exporter</span> <span class="token punctuation">=</span> <span class="token type">ExporterFactory</span><span class="token punctuation">.</span><span class="token method">GetExporter</span>(<span class="token variable">format</span>)<span class="token punctuation">;</span>
-                <span class="token type">string</span> <span class="token variable">exportedData</span> <span class="token punctuation">=</span> <span class="token variable">exporter</span><span class="token punctuation">.</span><span class="token method">Export</span>(<span class="token variable">users</span>)<span class="token punctuation">;</span>
-                <span class="token type">Console</span><span class="token punctuation">.</span><span class="token method">WriteLine</span>(<span class="token string">$"\n--- </span>{<span class="token variable">format</span><span class="token punctuation">.</span><span class="token method">ToUpper</span>()}<span class="token string"> OUTPUT ---\n</span>{<span class="token variable">exportedData</span>}<span class="token string">\n"</span>)<span class="token punctuation">;</span>
+                IDataExporter exporter = ExporterFactory.GetExporter(format);
+                string exportedData = exporter.Export(users);
+                Console.WriteLine($"\n--- {format.ToUpper()} OUTPUT ---\n{exportedData}\n");
             }
-            <span class="token keyword">catch</span> (<span class="token type">NotSupportedException</span> <span class="token variable">ex</span>)
+            catch (NotSupportedException ex)
             {
-                <span class="token type">Console</span><span class="token punctuation">.</span><span class="token method">WriteLine</span>(<span class="token variable">ex</span><span class="token punctuation">.</span><span class="token variable">Message</span>)<span class="token punctuation">;</span>
+                Console.WriteLine(ex.Message);
             }
         }
     }
@@ -742,7 +724,7 @@
     <footer class="mt-16 py-8 bg-white border-t">
         <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
             <div class="flex justify-center mb-4">
-                <a href="lld_homepage.html" class="btn btn-primary">Return to Homepage</a>
+                <a href="roadmap.html" class="btn btn-primary">Return to Homepage</a>
             </div>
             <p class="text-gray-500">&copy; 2025 OOP Foundations. All Rights Reserved.</p>
             <p class="text-sm mt-1 text-gray-500">A self-contained learning module.</p>
@@ -751,311 +733,33 @@
 
     <script>
         document.addEventListener('DOMContentLoaded', function () {
-            // --- Copy-to-Clipboard Functionality ---
-            document.querySelectorAll('pre').forEach(block => {
-                const code = block.querySelector('code');
-                if (code) {
-                    const copyButton = document.createElement('button');
-                    copyButton.textContent = 'Copy';
-                    copyButton.className = 'copy-btn btn';
-                    block.appendChild(copyButton);
-
-                    copyButton.addEventListener('click', () => {
-                        const textArea = document.createElement('textarea');
-                        textArea.value = code.innerText;
-                        document.body.appendChild(textArea);
-                        textArea.select();
-                        document.execCommand('copy');
-                        document.body.removeChild(textArea);
-
-                        copyButton.textContent = 'Copied!';
-                        setTimeout(() => {
-                            copyButton.textContent = 'Copy';
-                        }, 2000);
+            // --- Copy-to-Clipboard ---
+            document.querySelectorAll('.copy-btn').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    const code = btn.parentElement.querySelector('pre code').innerText;
+                    navigator.clipboard.writeText(code).then(() => {
+                        btn.textContent = 'Copied!';
+                        setTimeout(() => btn.textContent = 'Copy', 2000);
                     });
-                }
+                });
             });
-            
-            // --- Sticky ToC Active State Logic ---
-            const tocLinks = document.querySelectorAll('.toc-link');
+
+            // --- Active TOC Link ---
             const sections = document.querySelectorAll('main section');
-
-            const tocObserver = new IntersectionObserver((entries) => {
-                let activeSectionId = null;
-                
-                for (const entry of entries) {
+            const tocLinks = document.querySelectorAll('.toc-link');
+            const observer = new IntersectionObserver(entries => {
+                entries.forEach(entry => {
                     if (entry.isIntersecting) {
-                        activeSectionId = entry.target.id;
-                        break;
-                    }
-                }
-                
-                tocLinks.forEach(link => {
-                    link.classList.remove('active');
-                    if (activeSectionId && link.getAttribute('href') === `#${activeSectionId}`) {
-                        link.classList.add('active');
-                    }
-                });
-
-            }, { rootMargin: '0px 0px -80% 0px', threshold: 0 });
-
-            sections.forEach(section => {
-                tocObserver.observe(section);
-            });
-
-            // --- Solution Toggle ---
-            const toggleBtn = document.getElementById('toggle-solution-btn');
-            const solutionContent = document.getElementById('solution-content');
-            if (toggleBtn && solutionContent) {
-                toggleBtn.addEventListener('click', () => {
-                    const isHidden = solutionContent.classList.contains('hidden');
-                    if (isHidden) {
-                        solutionContent.classList.remove('hidden');
-                        toggleBtn.textContent = 'Hide Solution';
-                    } else {
-                        solutionContent.classList.add('hidden');
-                        toggleBtn.textContent = 'Show Solution';
-                    }
-                });
-            }
-
-            // --- Quiz Data and Logic ---
-            const quizData = [
-                {
-                    question: "What is the primary purpose of an interface in C#?",
-                    options: [
-                        "To provide a base implementation for derived classes.",
-                        "To define a contract of members that a class must implement.",
-                        "To allow a class definition to be split across multiple files.",
-                        "To directly instantiate objects."
-                    ],
-                    correctAnswer: "To define a contract of members that a class must implement."
-                },
-                {
-                    question: "Can a C# class inherit from multiple classes and implement multiple interfaces?",
-                    options: [
-                        "Yes, it can inherit from multiple classes and implement multiple interfaces.",
-                        "No, it can only inherit from one class but can implement multiple interfaces.",
-                        "Yes, it can inherit from multiple classes but can only implement one interface.",
-                        "No, it can only inherit from one class and implement one interface."
-                    ],
-                    correctAnswer: "No, it can only inherit from one class but can implement multiple interfaces."
-                },
-                {
-                    question: "What is the main benefit of using Partial Classes?",
-                    options: [
-                        "To improve runtime performance.",
-                        "To enforce a strict contract on a class.",
-                        "To separate auto-generated code from developer-written code.",
-                        "To enable multiple inheritance."
-                    ],
-                    correctAnswer: "To separate auto-generated code from developer-written code."
-                },
-                {
-                    question: "The Interface Segregation Principle (ISP) suggests that...",
-                    options: [
-                        "Interfaces should be as large as possible to cover all use cases.",
-                        "Classes should not be forced to implement interfaces they do not use.",
-                        "A class should have only one reason to change.",
-                        "Objects should be replaceable with their subtypes without altering correctness."
-                    ],
-                    correctAnswer: "Classes should not be forced to implement interfaces they do not use."
-                },
-                 {
-                    question: "In a Factory Pattern, what is the role of the interface?",
-                    options: [
-                        "The factory itself must implement an interface.",
-                        "The interface is not used in the Factory Pattern.",
-                        "It serves as the return type for the factory method, decoupling the client from concrete classes.",
-                        "It holds the logic for creating objects."
-                    ],
-                    correctAnswer: "It serves as the return type for the factory method, decoupling the client from concrete classes."
-                }
-            ];
-
-            const quizContainer = document.getElementById('quiz-container');
-            if (quizContainer) {
-                quizData.forEach((q, index) => {
-                    const questionEl = document.createElement('div');
-                    questionEl.className = 'bg-white p-6 rounded-lg shadow-sm border';
-                    
-                    let optionsHtml = '';
-                    q.options.forEach(option => {
-                        optionsHtml += `<div class="quiz-option border rounded-md p-3 mt-2 cursor-pointer hover:bg-gray-100" data-question="${index}">${option}</div>`;
-                    });
-
-                    questionEl.innerHTML = `
-                        <p class="font-semibold text-lg">${index + 1}. ${q.question}</p>
-                        <div class="mt-4 space-y-2">${optionsHtml}</div>
-                        <div id="feedback-${index}" class="mt-3 text-sm font-medium"></div>
-                    `;
-                    quizContainer.appendChild(questionEl);
-                });
-
-                quizContainer.addEventListener('click', (e) => {
-                    if (e.target.classList.contains('quiz-option')) {
-                        const questionIndex = e.target.getAttribute('data-question');
-                        const selectedAnswer = e.target.textContent;
-                        const questionData = quizData[questionIndex];
-                        const feedbackEl = document.getElementById(`feedback-${questionIndex}`);
-                        
-                        const allOptions = document.querySelectorAll(`.quiz-option[data-question="${questionIndex}"]`);
-                        allOptions.forEach(opt => {
-                            opt.classList.remove('correct', 'incorrect');
-                            opt.style.pointerEvents = 'none'; 
+                        tocLinks.forEach(link => {
+                            link.classList.remove('active');
+                            if (link.getAttribute('href') === `#${entry.target.id}`) {
+                                link.classList.add('active');
+                            }
                         });
-
-                        if (selectedAnswer === questionData.correctAnswer) {
-                            e.target.classList.add('correct');
-                            feedbackEl.textContent = 'Correct!';
-                            feedbackEl.style.color = '#38A169';
-                        } else {
-                            e.target.classList.add('incorrect');
-                            feedbackEl.textContent = `Incorrect. The correct answer is: "${questionData.correctAnswer}"`;
-                            feedbackEl.style.color = '#E53E3E';
-                            allOptions.forEach(opt => {
-                                if(opt.textContent === questionData.correctAnswer) {
-                                    opt.classList.add('correct');
-                                }
-                            });
-                        }
                     }
                 });
-            }
-            
-            // --- Interactive Canvas Visualization (Performance Optimized) ---
-            const canvas = document.getElementById('interfaceCanvas');
-            if (canvas) {
-                const ctx = canvas.getContext('2d');
-                let frame = 0;
-                let animationFrameId;
-
-                const resizeCanvas = () => {
-                    const container = canvas.parentElement;
-                    canvas.width = container.clientWidth;
-                    canvas.height = container.clientHeight;
-                };
-
-                const interfaceBox = { x: 50, y: 120, w: 150, h: 60 };
-                const classBoxes = [
-                    { x: 350, y: 30, w: 120, h: 50, name: 'Circle' },
-                    { x: 350, y: 125, w: 120, h: 50, name: 'Square' },
-                    { x: 350, y: 220, w: 120, h: 50, name: 'Triangle' },
-                ];
-
-                function draw() {
-                    ctx.clearRect(0, 0, canvas.width, canvas.height);
-                    
-                    ctx.fillStyle = '#3D352E';
-                    ctx.strokeStyle = '#C06A47';
-                    ctx.lineWidth = 2;
-                    ctx.strokeRect(interfaceBox.x, interfaceBox.y, interfaceBox.w, interfaceBox.h);
-                    ctx.font = '14px Inter';
-                    ctx.textAlign = 'center';
-                    ctx.fillText('IDrawable', interfaceBox.x + interfaceBox.w / 2, interfaceBox.y + 25);
-                    ctx.font = '12px "Roboto Mono"';
-                    ctx.fillText('+ Draw()', interfaceBox.x + interfaceBox.w / 2, interfaceBox.y + 45);
-
-                    classBoxes.forEach((box, i) => {
-                        const progress = Math.min(1, Math.max(0, (frame - i * 30) / 60));
-                        
-                        if (progress > 0) {
-                            const currentX = interfaceBox.x + interfaceBox.w + (box.x - (interfaceBox.x + interfaceBox.w)) * progress;
-                            
-                            ctx.beginPath();
-                            ctx.moveTo(interfaceBox.x + interfaceBox.w, interfaceBox.y + interfaceBox.h / 2);
-                            ctx.bezierCurveTo(interfaceBox.x + interfaceBox.w + 50, interfaceBox.y + interfaceBox.h / 2, currentX - 50, box.y + box.h / 2, currentX, box.y + box.h / 2);
-                            ctx.strokeStyle = '#3E8A86';
-                            ctx.setLineDash([5, 5]);
-                            ctx.stroke();
-                            ctx.setLineDash([]);
-                            
-                            if(progress === 1) {
-                                ctx.strokeStyle = '#3E8A86';
-                                ctx.strokeRect(box.x, box.y, box.w, box.h);
-                                ctx.fillStyle = '#3D352E';
-                                ctx.font = '14px Inter';
-                                ctx.fillText(box.name, box.x + box.w / 2, box.y + 20);
-                                ctx.font = '12px "Roboto Mono"';
-                                ctx.fillText('+ Draw() { ... }', box.x + box.w / 2, box.y + 40);
-                            }
-                        }
-                    });
-
-                    frame++;
-                    if (frame > 300) frame = 0;
-                    animationFrameId = requestAnimationFrame(draw);
-                }
-                
-                const canvasObserver = new IntersectionObserver((entries) => {
-                    if (entries[0].isIntersecting) {
-                        frame = 0; // Restart animation when it comes into view
-                        if (!animationFrameId) {
-                            animationFrameId = requestAnimationFrame(draw);
-                        }
-                    } else {
-                        cancelAnimationFrame(animationFrameId);
-                        animationFrameId = null;
-                    }
-                }, { threshold: 0.1 });
-
-                canvasObserver.observe(canvas);
-                window.addEventListener('resize', resizeCanvas);
-                resizeCanvas();
-            }
-
-            // --- Factory Chart.js Visualization ---
-            const factoryCtx = document.getElementById('factoryChart');
-            if(factoryCtx) {
-                new Chart(factoryCtx, {
-                    type: 'bar',
-                    data: {
-                        labels: ['PayPalProcessor', 'StripeProcessor', 'FutureProcessor'],
-                        datasets: [{
-                            label: 'Objects Created by Factory',
-                            data: [120, 185, 0],
-                            backgroundColor: [
-                                'rgba(62, 138, 134, 0.6)',
-                                'rgba(192, 106, 71, 0.6)',
-                                'rgba(150, 150, 150, 0.6)'
-                            ],
-                            borderColor: [
-                                'rgb(62, 138, 134)',
-                                'rgb(192, 106, 71)',
-                                'rgb(150, 150, 150)'
-                            ],
-                            borderWidth: 1
-                        }]
-                    },
-                    options: {
-                        responsive: true,
-                        maintainAspectRatio: false,
-                        scales: {
-                            y: {
-                                beginAtZero: true
-                            }
-                        },
-                        plugins: {
-                            title: {
-                                display: true,
-                                text: 'Factory Pattern: Decoupling Client from Concrete Classes',
-                                font: { size: 16 }
-                            },
-                            subtitle: {
-                                display: true,
-                                text: 'The client requests an IPaymentProcessor, and the factory provides a concrete instance.',
-                                padding: { bottom: 20 }
-                            },
-                            tooltip: {
-                                callbacks: {
-                                    footer: (tooltipItems) => 'The client code does not know or care which specific class instance it received.'
-                                }
-                            }
-                        }
-                    }
-                });
-            }
-
+            }, { rootMargin: '-40% 0px -60% 0px' });
+            sections.forEach(section => observer.observe(section));
         });
     </script>
 </body>

--- a/day_7.html
+++ b/day_7.html
@@ -3,85 +3,154 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>OOP Foundations: Static Classes & Records</title>
+    <title>Day 7: Static Classes & Records - OOP Foundations</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Roboto+Mono:wght@400;500&display=swap" rel="stylesheet">
-    <!-- Chosen Palette: Warm Neutrals with Indigo Accent -->
-    <!-- Application Structure Plan: A responsive sidebar navigation structure is used to break the dense document into its logical sections (Static Classes, Records, Advanced Topics, etc.). This architecture was chosen to transform a long, linear document into a user-driven, non-linear learning module. It enhances usability by allowing users to instantly jump to specific topics of interest without excessive scrolling, and provides a clear map of the content. On mobile, the sidebar collapses into an accessible menu. -->
-    <!-- Visualization & Content Choices: 
-        1. Report Info: Core concepts of static classes and records. Goal: Inform/Organize. Viz/Method: Styled text sections with interactive sidebar navigation. Interaction: Clicking nav links smoothly scrolls to the relevant section. Justification: Provides clear structure and easy navigation for a text-heavy document. Library/Method: HTML/CSS/JS.
-        2. Report Info: Code examples in C#. Goal: Inform/Utility. Viz/Method: Styled code blocks. Interaction: A "Copy" button on each block copies the code to the clipboard. Justification: Improves the practical utility of the guide for developers. Library/Method: Vanilla JS.
-        3. Report Info: Analogies for complex concepts. Goal: Clarify. Viz/Method: Visually distinct callout boxes (HTML/Tailwind). Interaction: None. Justification: Breaks up the text and highlights important conceptual aids. Library/Method: N/A.
-        4. Report Info: UML Diagram. Goal: Visualize structure. Viz/Method: Structured HTML and Tailwind CSS to mimic a class diagram. Interaction: None. Justification: Provides a visual representation without external libraries, adhering to constraints. Static members are underlined per UML spec. Library/Method: HTML/Tailwind.
-        5. Report Info: Knowledge Check Quiz. Goal: Assess/Engage. Viz/Method: Interactive multiple-choice form. Interaction: Users select answers and click "Check Answers". The UI provides immediate visual feedback (correct/incorrect) and reveals explanations. Justification: Transforms a static quiz into an active learning tool. Library/Method: Vanilla JS.
-    -->
-    <!-- CONFIRMATION: NO SVG graphics used. NO Mermaid JS used. -->
     <style>
         body {
             font-family: 'Inter', sans-serif;
-            background-color: #f8fafc; /* slate-50 */
-            color: #1f2937; /* gray-800 */
+            background-color: #FFFFFF;
+            color: #3D352E;
         }
-        pre, code {
+        h1, h2, h3, h4, h5, h6 {
+            font-family: 'Inter', sans-serif;
+            font-weight: 700;
+        }
+        pre {
+            background-color: #1E1E1E;
+            color: #D4D4D4;
             font-family: 'Roboto Mono', monospace;
-        }
-        .section-target {
-            scroll-margin-top: 80px;
-        }
-        .nav-link.active {
-            background-color: #eef2ff; /* indigo-50 */
-            color: #4338ca; /* indigo-700 */
-            font-weight: 600;
-        }
-        .code-block {
+            border-radius: 0.5rem;
+            padding: 1.25rem;
             position: relative;
+            overflow-x: auto;
+            border: 1px solid #3a404a;
         }
-        .copy-button {
+        pre code {
+            background-color: transparent !important;
+            color: inherit;
+            padding: 0;
+            font-size: inherit;
+            border-radius: 0;
+        }
+        .prose-custom :not(pre) > code {
+            background-color: #F3F4F6;
+            color: #C06A47;
+            padding: 0.2em 0.4em;
+            border-radius: 3px;
+            font-family: 'Roboto Mono', monospace;
+            font-size: 0.9em;
+        }
+        .btn {
+            display: inline-block;
+            font-weight: 600;
+            padding: 0.5rem 1rem;
+            border-radius: 0.375rem;
+            transition: all 0.2s ease-in-out;
+            cursor: pointer;
+            text-align: center;
+        }
+        .btn-primary {
+            background-color: #C06A47; /* Sienna */
+            color: #FFFFFF;
+            border: 1px solid transparent;
+        }
+        .btn-primary:hover {
+            background-color: #A95A3A; /* Darker Sienna */
+        }
+        .copy-btn {
             position: absolute;
-            top: 0.5rem;
-            right: 0.5rem;
-            background-color: #4b5563; /* gray-600 */
+            top: 0.75rem;
+            right: 0.75rem;
+            background-color: #4A5568;
             color: white;
+            border: none;
             padding: 0.25rem 0.5rem;
             border-radius: 0.25rem;
             font-size: 0.75rem;
-            cursor: pointer;
             opacity: 0;
-            transition: opacity 0.2s;
+            transition: all 0.2s;
         }
-        .code-block:hover .copy-button {
+        pre:hover .copy-btn {
             opacity: 1;
         }
-        .uml-underline {
-            text-decoration: underline;
+        .copy-btn:hover {
+            background-color: #2D3748;
         }
+        .toc-link {
+            transition: all 0.2s ease-in-out;
+            border-left: 2px solid transparent;
+        }
+        .toc-link:hover {
+            color: #3E8A86; /* Teal */
+            border-left-color: #3E8A86;
+        }
+        .toc-link.active {
+            color: #C06A47; /* Sienna */
+            border-left-color: #C06A47;
+            font-weight: 700;
+        }
+        .prose-custom { max-width: 80ch; }
+        .prose-custom h2 { margin-top: 2.5em; margin-bottom: 1em; }
+        .prose-custom h3 { margin-top: 2em; margin-bottom: 0.8em; }
+        .prose-custom p, .prose-custom ul, .prose-custom ol { line-height: 1.7; }
+        .shadow-sm { box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05); }
+        .bg-white { background-color: #FFFFFF; }
+        .border, .border-t { border-color: #e5e7eb; }
     </style>
 </head>
-<body class="bg-slate-50">
-    <header class="text-center mb-10">
-        <h2 id="greeting" class="text-xl text-slate-500">Good Evening!</h2>
-        <h1 class="text-4xl sm:text-5xl font-extrabold text-slate-800 mt-1 tracking-tight">Low-Level Design Bootcamp</h1>
-        <p class="mt-3 text-slate-500 max-w-xl mx-auto">Your 60-Day Interactive Roadmap to Mastering Backend Engineering.</p>
+<body class="antialiased">
+
+    <!-- Header -->
+    <header class="bg-white shadow-md fixed top-0 left-0 right-0 z-50">
+        <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex justify-between items-center py-3">
+                <div class="text-2xl font-bold text-sienna-800">
+                    <a href="roadmap.html">OOP Foundations</a>
+                </div>
+                <nav class="hidden md:flex space-x-4">
+                    <a href="day_1.html" class="text-gray-600 hover:text-teal-600 transition">Day 1</a>
+                    <a href="day_2.html" class="text-gray-600 hover:text-teal-600 transition">Day 2</a>
+                    <a href="day_3.html" class="text-gray-600 hover:text-teal-600 transition">Day 3</a>
+                    <a href="day_4.html" class="text-gray-600 hover:text-teal-600 transition">Day 4</a>
+                    <a href="day_5.html" class="text-gray-600 hover:text-teal-600 transition">Day 5</a>
+                    <a href="day_6.html" class="text-gray-600 hover:text-teal-600 transition">Day 6</a>
+                    <a href="day_7.html" class="font-bold text-teal-600">Day 7</a>
+                </nav>
+                <!-- Return to Homepage button removed from here -->
+            </div>
+        </div>
     </header>
 
-    <div class="max-w-screen-xl mx-auto">
-        <div class="flex flex-col md:flex-row">
-            <!-- Main Content -->
-            <main class="flex-1 p-6 sm:p-8 lg:p-12">
-                <a href="lld_homepage.html" class="text-teal-600 hover:text-teal-800 font-semibold transition-colors duration-200 inline-flex items-center">
-                    <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path></svg>
-                    Return to Homepage
-                </a>
-                <header class="mb-12">
-                    <h1 class="text-4xl font-extrabold tracking-tight text-slate-900">OOP Foundations, Day 7: Static Classes & Records</h1>
-                    <p class="mt-2 text-lg text-slate-600">An interactive guide to the architect's toolkit for utility and data patterns in C#.</p>
-                </header>
+    <main class="container mx-auto px-4 sm:px-6 lg:px-8 pt-24">
+        <div class="flex justify-between items-center mb-12">
+            <div class="text-center">
+                <h1 class="text-4xl md:text-5xl font-bold tracking-tight text-sienna-800">Day 7: Static Classes & Records</h1>
+                <p class="mt-4 text-xl text-gray-600">An interactive guide to the architect's toolkit for utility and data patterns in C#.</p>
+            </div>
+            <a href="roadmap.html" class="btn btn-primary whitespace-nowrap">Return to Homepage</a>
+        </div>
 
-                <div class="prose prose-slate max-w-none prose-h3:text-slate-800 prose-h3:font-semibold prose-h4:text-indigo-600 prose-h4:font-semibold prose-a:text-indigo-600">
-                    
-                    <section id="section1" class="section-target mb-16">
+        <div class="flex flex-col lg:flex-row-reverse lg:space-x-reverse lg:space-x-12">
+            <aside class="w-full lg:w-1/4 lg:sticky lg:top-24 self-start mb-12 lg:mb-0">
+                <div class="p-4 rounded-lg bg-white shadow-sm border">
+                    <h3 class="text-lg font-semibold mb-4">On This Page</h3>
+                    <nav id="toc-nav" class="flex flex-col space-y-2">
+                        <a href="#section1" class="toc-link pl-2 text-gray-600">1. Static Classes</a>
+                        <a href="#section2" class="toc-link pl-2 text-gray-600">2. C# Records</a>
+                        <a href="#section3" class="toc-link pl-2 text-gray-600">3. Advanced Topics</a>
+                        <a href="#section4" class="toc-link pl-2 text-gray-600">4. Coding Practice</a>
+                        <a href="#section5" class="toc-link pl-2 text-gray-600">5. UML Modeling</a>
+                        <a href="#section6" class="toc-link pl-2 text-gray-600">6. Case Study</a>
+                        <a href="#section7" class="toc-link pl-2 text-gray-600">7. Knowledge Assessment</a>
+                    </nav>
+                </div>
+            </aside>
+
+            <div class="w-full lg:w-3/4 prose-custom">
+                 <section id="section1" class="section-target mb-16">
                         <h3 class="text-2xl border-b border-slate-200 pb-2 mb-6">Section 1: The Utility Pattern — Static Classes in .NET</h3>
                         <p>In the landscape of object-oriented programming, the primary unit of organization is the class, a blueprint for creating objects that encapsulate both state (data) and behavior (methods). However, a common design challenge arises: where should one place functionality that is inherently stateless and does not logically belong to any specific object instance? Consider fundamental operations like calculating the absolute value of a number or checking if a file exists on disk. These are pure actions, not entities with identities. Forcing such functions into an instantiable class can feel artificial and lead to cumbersome code, requiring developers to create an object for the sole purpose of calling a single method.</p>
                         <p>This is the problem space that static classes in C# are designed to solve. They represent a pragmatic "compromise between pure object-oriented design and simplicity," serving as a dedicated, organized container for methods and data that are global to an application's scope.</p>
@@ -332,203 +401,50 @@ public void HandleRequest()
                             <div id="quiz-feedback" class="mt-4 space-y-4"></div>
                         </div>
                     </section>
-
-                </div>
-            </main>
-            <!-- Sidebar Navigation -->
-            <aside class="w-full md:w-64 lg:w-72 bg-white md:h-screen md:sticky md:top-0 border-b md:border-b-0 md:border-r border-slate-200">
-                <div class="p-4">
-                    <h2 class="text-lg font-bold text-indigo-600">Architect's Toolkit</h2>
-                    <p class="text-sm text-slate-500">Static Classes & Records</p>
-                </div>
-                <nav id="sidebar-nav" class="flex flex-col px-4 pb-4">
-                    <a href="#section1" class="nav-link text-slate-600 hover:bg-slate-100 rounded-md px-3 py-2 transition-colors duration-150 text-sm">1. Static Classes</a>
-                    <a href="#section2" class="nav-link text-slate-600 hover:bg-slate-100 rounded-md px-3 py-2 transition-colors duration-150 text-sm">2. C# Records</a>
-                    <a href="#section3" class="nav-link text-slate-600 hover:bg-slate-100 rounded-md px-3 py-2 transition-colors duration-150 text-sm">3. Advanced Topics</a>
-                    <a href="#section4" class="nav-link text-slate-600 hover:bg-slate-100 rounded-md px-3 py-2 transition-colors duration-150 text-sm">4. Coding Practice</a>
-                    <a href="#section5" class="nav-link text-slate-600 hover:bg-slate-100 rounded-md px-3 py-2 transition-colors duration-150 text-sm">5. UML Modeling</a>
-                    <a href="#section6" class="nav-link text-slate-600 hover:bg-slate-100 rounded-md px-3 py-2 transition-colors duration-150 text-sm">6. Case Study</a>
-                    <a href="#section7" class="nav-link text-slate-600 hover:bg-slate-100 rounded-md px-3 py-2 transition-colors duration-150 text-sm">7. Knowledge Assessment</a>
-                </nav>
-            </aside>
+            </div>
         </div>
-    </div>
-    <footer class="text-center mt-16 py-8 border-t border-slate-200">
-        <p class="text-slate-700 font-semibold">Low-Level Design Bootcamp</p>
-        <p class="text-sm text-slate-500 mt-2">A personalized learning roadmap curated by Mr. Mahesh Singare.</p>
-        <p class="text-xs text-slate-400 mt-4">&copy; 2025. All Rights Reserved.</p>
+    </main>
+
+    <footer class="mt-16 py-8 bg-white border-t">
+        <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
+            <div class="flex justify-center mb-4">
+                <a href="roadmap.html" class="btn btn-primary">Return to Homepage</a>
+            </div>
+            <p class="text-gray-500">&copy; 2025 OOP Foundations. All Rights Reserved.</p>
+            <p class="text-sm mt-1 text-gray-500">A self-contained learning module.</p>
+        </div>
     </footer>
 
-<script>
-document.addEventListener('DOMContentLoaded', () => {
-    // --- Code Block Copy Functionality ---
-    const codeBlocks = document.querySelectorAll('.code-block');
-    codeBlocks.forEach(block => {
-        const pre = block.querySelector('pre');
-        const code = pre.querySelector('code');
-        const button = document.createElement('button');
-        button.textContent = 'Copy';
-        button.className = 'copy-button';
-        block.appendChild(button);
-
-        button.addEventListener('click', () => {
-            navigator.clipboard.writeText(code.innerText).then(() => {
-                button.textContent = 'Copied!';
-                setTimeout(() => {
-                    button.textContent = 'Copy';
-                }, 2000);
-            });
-        });
-    });
-
-    // --- Sidebar Navigation Active State ---
-    const navLinks = document.querySelectorAll('.nav-link');
-    const sections = document.querySelectorAll('.section-target');
-
-    const observerOptions = {
-        root: null,
-        rootMargin: '0px',
-        threshold: 0.3
-    };
-
-    const observer = new IntersectionObserver((entries) => {
-        entries.forEach(entry => {
-            if (entry.isIntersecting) {
-                const id = entry.target.getAttribute('id');
-                navLinks.forEach(link => {
-                    link.classList.toggle('active', link.getAttribute('href') === `#${id}`);
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            // --- Copy-to-Clipboard ---
+            document.querySelectorAll('.copy-btn').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    const code = btn.parentElement.querySelector('pre code').innerText;
+                    navigator.clipboard.writeText(code).then(() => {
+                        btn.textContent = 'Copied!';
+                        setTimeout(() => btn.textContent = 'Copy', 2000);
+                    });
                 });
-            }
-        });
-    }, observerOptions);
-
-    sections.forEach(section => {
-        observer.observe(section);
-    });
-
-    // --- Quiz Functionality ---
-    const quizData = [
-        {
-            question: "Which of the following is NOT a feature of a C# static class?",
-            options: ["Cannot be instantiated.", "Can implement interfaces.", "Is implicitly sealed.", "Can only contain static members."],
-            answer: 1,
-            explanation: "Static classes cannot be instantiated, so they cannot fulfill an interface contract."
-        },
-        {
-            question: "When is the static constructor of a class called?",
-            options: ["Every time a static method is called.", "Only once, before the first time any member of the class is accessed.", "Every time an object of the class is created.", "It must be called manually."],
-            answer: 1,
-            explanation: "The CLR guarantees this behavior for thread-safe initialization, calling it at most once before the first member access."
-        },
-        {
-            question: "What is the primary purpose of the `record` type in C#?",
-            options: ["To define classes with complex, stateful behavior.", "To create types that are optimized for performance-critical calculations.", "To provide a concise syntax for creating immutable, data-centric types with value equality.", "To replace the need for structs."],
-            answer: 2,
-            explanation: "This is the core design motivation for records: data-centric types with minimal boilerplate."
-        },
-        {
-            question: "True or False: Two record instances with identical property values will be considered equal by the `==` operator.",
-            options: ["True", "False"],
-            answer: 0,
-            explanation: "Records have compiler-synthesized value equality, which includes an override for the `==` operator."
-        },
-        {
-            question: "What does the `with` expression do when used with a record?",
-            options: ["It modifies the properties of the existing record instance.", "It creates a new record instance by copying the original and applying changes.", "It can only be used to change one property at a time.", "It converts a record to a class."],
-            answer: 1,
-            explanation: "This is called non-destructive mutation and is key to working with immutable types."
-        },
-        {
-            question: "What is the primary risk of using a mutable public static field in a multithreaded application?",
-            options: ["Poor performance due to garbage collection.", "A StackOverflowException.", "Race conditions leading to data corruption.", "Inability to access the field from other assemblies."],
-            answer: 2,
-            explanation: "Unsynchronized access to shared mutable state is a primary cause of concurrency bugs."
-        },
-        {
-            question: "In a UML class diagram, what is the standard way to denote a static method?",
-            options: ["Writing the method name in italics.", "Underlining the method name.", "Prefixing the method name with a * symbol.", "Using the <<static>> stereotype next to the method."],
-            answer: 1,
-            explanation: "Underlining is the standard UML convention for all static members (attributes and operations)."
-        }
-    ];
-
-    const quizContainer = document.getElementById('quiz-container');
-    const checkBtn = document.getElementById('check-quiz-btn');
-    const resultsContainer = document.getElementById('quiz-results');
-    const scoreEl = document.getElementById('quiz-score');
-    const feedbackEl = document.getElementById('quiz-feedback');
-
-    function buildQuiz() {
-        quizData.forEach((q, index) => {
-            const questionDiv = document.createElement('div');
-            questionDiv.id = `question-${index}`;
-            let optionsHTML = '';
-            q.options.forEach((option, i) => {
-                optionsHTML += `
-                    <label class="block flex items-center p-3 rounded-lg border border-slate-200 hover:bg-slate-50 transition-colors cursor-pointer">
-                        <input type="radio" name="q${index}" value="${i}" class="mr-3 h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300">
-                        <span>${option}</span>
-                    </label>
-                `;
             });
 
-            questionDiv.innerHTML = `
-                <p class="font-semibold text-slate-800">${index + 1}. ${q.question}</p>
-                <div class="mt-3 space-y-2">${optionsHTML}</div>
-            `;
-            quizContainer.appendChild(questionDiv);
-        });
-    }
-
-    function checkAnswers() {
-        let score = 0;
-        feedbackEl.innerHTML = ''; 
-
-        quizData.forEach((q, index) => {
-            const questionDiv = document.getElementById(`question-${index}`);
-            const selected = questionDiv.querySelector(`input[name="q${index}"]:checked`);
-            
-            const feedbackDiv = document.createElement('div');
-            feedbackDiv.className = 'p-4 rounded-lg';
-
-            if (!selected) {
-                 feedbackDiv.innerHTML = `<p class="font-bold">${index + 1}. ${q.question}</p><p class="mt-1 text-amber-700">No answer selected.</p>`;
-                 feedbackDiv.classList.add('bg-amber-50');
-            } else {
-                const userAnswer = parseInt(selected.value);
-                const labels = questionDiv.querySelectorAll('label');
-
-                labels.forEach((label, i) => {
-                    label.classList.remove('bg-red-100', 'border-red-300', 'bg-green-100', 'border-green-300');
-                    if (i === q.answer) { 
-                        label.classList.add('bg-green-100', 'border-green-300');
-                    }
-                    if (i === userAnswer && userAnswer !== q.answer) {
-                        label.classList.add('bg-red-100', 'border-red-300');
+            // --- Active TOC Link ---
+            const sections = document.querySelectorAll('main section');
+            const tocLinks = document.querySelectorAll('.toc-link');
+            const observer = new IntersectionObserver(entries => {
+                entries.forEach(entry => {
+                    if (entry.isIntersecting) {
+                        tocLinks.forEach(link => {
+                            link.classList.remove('active');
+                            if (link.getAttribute('href') === `#${entry.target.id}`) {
+                                link.classList.add('active');
+                            }
+                        });
                     }
                 });
-
-                if (userAnswer === q.answer) {
-                    score++;
-                    feedbackDiv.innerHTML = `<p class="font-bold">${index + 1}. Correct!</p><p class="mt-1">${q.explanation}</p>`;
-                    feedbackDiv.classList.add('bg-green-50');
-                } else {
-                    feedbackDiv.innerHTML = `<p class="font-bold">${index + 1}. Incorrect.</p><p class="mt-1">${q.explanation}</p>`;
-                    feedbackDiv.classList.add('bg-red-50');
-                }
-            }
-            feedbackEl.appendChild(feedbackDiv);
+            }, { rootMargin: '-40% 0px -60% 0px' });
+            sections.forEach(section => observer.observe(section));
         });
-
-        scoreEl.textContent = `Your Score: ${score} out of ${quizData.length}`;
-        resultsContainer.classList.remove('hidden');
-        resultsContainer.scrollIntoView({ behavior: 'smooth' });
-    }
-
-    buildQuiz();
-    checkBtn.addEventListener('click', checkAnswers);
-});
-</script>
-
+    </script>
 </body>
 </html>

--- a/template.html
+++ b/template.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>__PAGE_TITLE__ - OOP Foundations</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Roboto+Mono:wght@400;500&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Inter', sans-serif;
+            background-color: #FFFFFF;
+            color: #3D352E;
+        }
+        h1, h2, h3, h4, h5, h6 {
+            font-family: 'Inter', sans-serif;
+            font-weight: 700;
+        }
+        pre {
+            background-color: #1E1E1E;
+            color: #D4D4D4;
+            font-family: 'Roboto Mono', monospace;
+            border-radius: 0.5rem;
+            padding: 1.25rem;
+            position: relative;
+            overflow-x: auto;
+            border: 1px solid #3a404a;
+        }
+        pre code {
+            background-color: transparent !important;
+            color: inherit;
+            padding: 0;
+            font-size: inherit;
+            border-radius: 0;
+        }
+        .prose-custom :not(pre) > code {
+            background-color: #F3F4F6;
+            color: #C06A47;
+            padding: 0.2em 0.4em;
+            border-radius: 3px;
+            font-family: 'Roboto Mono', monospace;
+            font-size: 0.9em;
+        }
+        .btn {
+            display: inline-block;
+            font-weight: 600;
+            padding: 0.5rem 1rem;
+            border-radius: 0.375rem;
+            transition: all 0.2s ease-in-out;
+            cursor: pointer;
+            text-align: center;
+        }
+        .btn-primary {
+            background-color: #C06A47; /* Sienna */
+            color: #FFFFFF;
+            border: 1px solid transparent;
+        }
+        .btn-primary:hover {
+            background-color: #A95A3A; /* Darker Sienna */
+        }
+        .copy-btn {
+            position: absolute;
+            top: 0.75rem;
+            right: 0.75rem;
+            background-color: #4A5568;
+            color: white;
+            border: none;
+            padding: 0.25rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            opacity: 0;
+            transition: all 0.2s;
+        }
+        pre:hover .copy-btn {
+            opacity: 1;
+        }
+        .copy-btn:hover {
+            background-color: #2D3748;
+        }
+        .toc-link {
+            transition: all 0.2s ease-in-out;
+            border-left: 2px solid transparent;
+        }
+        .toc-link:hover {
+            color: #3E8A86; /* Teal */
+            border-left-color: #3E8A86;
+        }
+        .toc-link.active {
+            color: #C06A47; /* Sienna */
+            border-left-color: #C06A47;
+            font-weight: 700;
+        }
+        .prose-custom { max-width: 80ch; }
+        .prose-custom h2 { margin-top: 2.5em; margin-bottom: 1em; }
+        .prose-custom h3 { margin-top: 2em; margin-bottom: 0.8em; }
+        .prose-custom p, .prose-custom ul, .prose-custom ol { line-height: 1.7; }
+        .shadow-sm { box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05); }
+        .bg-white { background-color: #FFFFFF; }
+        .border, .border-t { border-color: #e5e7eb; }
+    </style>
+</head>
+<body class="antialiased">
+
+    <!-- Header -->
+    <header class="bg-white shadow-md fixed top-0 left-0 right-0 z-50">
+        <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex justify-between items-center py-3">
+                <div class="text-2xl font-bold text-sienna-800">
+                    <a href="roadmap.html">OOP Foundations</a>
+                </div>
+                <nav class="hidden md:flex space-x-4">
+                    __DAY_NAV_LINKS__
+                </nav>
+                <!-- Return to Homepage button removed from here -->
+            </div>
+        </div>
+    </header>
+
+    <main class="container mx-auto px-4 sm:px-6 lg:px-8 pt-24">
+        <div class="flex justify-between items-center mb-12">
+            <div class="text-center">
+                <h1 class="text-4xl md:text-5xl font-bold tracking-tight text-sienna-800">__PAGE_TITLE__</h1>
+                <p class="mt-4 text-xl text-gray-600">__PAGE_SUBTITLE__</p>
+            </div>
+            <a href="roadmap.html" class="btn btn-primary whitespace-nowrap">Return to Homepage</a>
+        </div>
+
+        <div class="flex flex-col lg:flex-row-reverse lg:space-x-reverse lg:space-x-12">
+            <aside class="w-full lg:w-1/4 lg:sticky lg:top-24 self-start mb-12 lg:mb-0">
+                <div class="p-4 rounded-lg bg-white shadow-sm border">
+                    <h3 class="text-lg font-semibold mb-4">On This Page</h3>
+                    <nav id="toc-nav" class="flex flex-col space-y-2">
+                        __TOC_LINKS__
+                    </nav>
+                </div>
+            </aside>
+
+            <div class="w-full lg:w-3/4 prose-custom">
+                __MAIN_CONTENT__
+            </div>
+        </div>
+    </main>
+
+    <footer class="mt-16 py-8 bg-white border-t">
+        <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
+            <div class="flex justify-center mb-4">
+                <a href="roadmap.html" class="btn btn-primary">Return to Homepage</a>
+            </div>
+            <p class="text-gray-500">&copy; 2025 OOP Foundations. All Rights Reserved.</p>
+            <p class="text-sm mt-1 text-gray-500">A self-contained learning module.</p>
+        </div>
+    </footer>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            // --- Copy-to-Clipboard ---
+            document.querySelectorAll('.copy-btn').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    const code = btn.parentElement.querySelector('pre code').innerText;
+                    navigator.clipboard.writeText(code).then(() => {
+                        btn.textContent = 'Copied!';
+                        setTimeout(() => btn.textContent = 'Copy', 2000);
+                    });
+                });
+            });
+
+            // --- Active TOC Link ---
+            const sections = document.querySelectorAll('main section');
+            const tocLinks = document.querySelectorAll('.toc-link');
+            const observer = new IntersectionObserver(entries => {
+                entries.forEach(entry => {
+                    if (entry.isIntersecting) {
+                        tocLinks.forEach(link => {
+                            link.classList.remove('active');
+                            if (link.getAttribute('href') === `#${entry.target.id}`) {
+                                link.classList.add('active');
+                            }
+                        });
+                    }
+                });
+            }, { rootMargin: '-40% 0px -60% 0px' });
+            sections.forEach(section => observer.observe(section));
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
This commit standardizes the HTML structure, header, and footer for all day pages (day_1.html through day_7.html) to create a consistent user experience.

Key changes include:
- A new, fixed header with navigation links to all day pages.
- A new, consistent footer.
- The "Return to Homepage" button has been correctly placed in the main content area, next to the page title, and links to roadmap.html.
- The Table of Contents (TOC) has been moved to a right-hand sidebar on all pages, and the associated JavaScript for active link highlighting has been standardized.
- Cleaned up leftover temporary and versioned files from previous attempts.